### PR TITLE
Add accessible Expo candidate ranking

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,8 +1,8 @@
 # Ranked Choices mobile
 
-Phase 0 of the Ranked Choices Expo migration. This app currently provides a
-shortcode lookup and read-only ballot preview backed by the existing PHP API.
-It does not submit votes or authenticate users yet.
+Phase 1 of the Ranked Choices Expo migration. This app currently provides a
+shortcode lookup, ballot preview, and local candidate-ranking controls backed
+by the existing PHP API. It does not submit votes or authenticate users yet.
 
 ## Get started
 
@@ -63,11 +63,12 @@ connectivity will be designed alongside the later web deployment decision.
 - Expo Router and TypeScript scaffold
 - development API base URL selection
 - typed normalization of the legacy `get-candidates.php` response
-- ballot lookup and read-only candidate display
+- ballot lookup and accessible local candidate ranking
+- move-up, move-down, remove, and reset controls
 - loading, closed, not-found, malformed-response, and network-error handling
 
-Voting, authentication, production deployment, and domain association files
-are intentionally deferred to later RFC phases.
+Vote submission, authentication, production deployment, and domain association
+files are intentionally deferred to later slices.
 
 ## Expo resources
 

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
+        "@types/react-dom": "~19.2.3",
         "eslint": "^9.0.0",
         "eslint-config-expo": "~57.0.1",
         "typescript": "~6.0.3",
@@ -3263,6 +3264,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-test-renderer": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.2.2",
+    "@types/react-dom": "~19.2.3",
     "eslint": "^9.0.0",
     "eslint-config-expo": "~57.0.1",
     "typescript": "~6.0.3",

--- a/apps/mobile/src/app/ballot/[key]/index.tsx
+++ b/apps/mobile/src/app/ballot/[key]/index.tsx
@@ -1,5 +1,6 @@
 import { createLegacyApiClient } from '@/api/client';
 import { LegacyApiError, type BallotDetail } from '@/api/legacy-api';
+import { CandidateRanking } from '@/components/candidate-ranking';
 import { useLocalSearchParams } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
@@ -81,7 +82,7 @@ export default function BallotScreen() {
   return (
     <ScrollView contentContainerStyle={styles.scrollContent} style={styles.screen}>
       <View style={styles.content}>
-        <Text style={styles.eyebrow}>READ-ONLY BALLOT PREVIEW</Text>
+        <Text style={styles.eyebrow}>RANK YOUR CHOICES</Text>
         <Text style={styles.title}>{ballot.name}</Text>
         <Text style={styles.shortcode}>Shortcode: {ballot.key}</Text>
 
@@ -102,21 +103,12 @@ export default function BallotScreen() {
           ) : null}
         </View>
 
-        <Text style={styles.sectionTitle}>Candidates</Text>
+        <Text style={styles.sectionTitle}>Your ranking</Text>
         <Text style={styles.helpText}>
-          Candidate ordering is shown for connectivity testing. Ranking is not enabled in this
-          scaffold.
+          Put your favorite choice first. Use the controls to move or remove choices; you can reset
+          the ballot at any time.
         </Text>
-        <View style={styles.candidateList}>
-          {candidates.map((candidate, index) => (
-            <View key={candidate.id} style={styles.candidateRow}>
-              <View style={styles.rankBadge}>
-                <Text style={styles.rankText}>{index + 1}</Text>
-              </View>
-              <Text style={styles.candidateName}>{candidate.name}</Text>
-            </View>
-          ))}
-        </View>
+        <CandidateRanking candidates={candidates} orderedEntries={ballot.orderedEntries} />
 
         {groupFields.length ? (
           <Text style={styles.notice}>
@@ -156,27 +148,6 @@ const styles = StyleSheet.create({
   metaLabel: { color: '#436251', fontSize: 12, marginTop: 2 },
   sectionTitle: { color: '#1f3143', fontSize: 22, fontWeight: '800', marginTop: 30 },
   helpText: { color: '#52697f', fontSize: 14, lineHeight: 20, marginTop: 6 },
-  candidateList: { gap: 10, marginTop: 16 },
-  candidateRow: {
-    alignItems: 'center',
-    backgroundColor: '#ffffff',
-    borderColor: '#d9e0e7',
-    borderRadius: 14,
-    borderWidth: 1,
-    flexDirection: 'row',
-    padding: 14,
-  },
-  rankBadge: {
-    alignItems: 'center',
-    backgroundColor: '#12355b',
-    borderRadius: 18,
-    height: 36,
-    justifyContent: 'center',
-    marginRight: 13,
-    width: 36,
-  },
-  rankText: { color: '#ffffff', fontSize: 15, fontWeight: '800' },
-  candidateName: { color: '#1f3143', flex: 1, fontSize: 17, fontWeight: '700' },
   notice: {
     backgroundColor: '#fff3dc',
     borderRadius: 12,

--- a/apps/mobile/src/components/candidate-ranking.test.tsx
+++ b/apps/mobile/src/components/candidate-ranking.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import type { Candidate } from '@/api/legacy-api';
+
+import { CandidateRanking } from './candidate-ranking';
+
+const candidates: Candidate[] = [
+  { id: 1, name: 'Ada', image: '', hyperlink: '', color: null },
+  { id: 2, name: 'Grace', image: '', hyperlink: '', color: null },
+];
+
+describe('CandidateRanking', () => {
+  it('renders ranked candidates with accessible actions and boundary states', () => {
+    const html = renderToStaticMarkup(
+      <CandidateRanking candidates={candidates} orderedEntries={true} />,
+    );
+
+    expect(html).toContain('2 choices ranked');
+    expect(html).toContain('aria-label="Move Ada up"');
+    expect(html).toMatch(/<button[^>]*aria-disabled="true"[^>]*aria-label="Move Ada up"/);
+    expect(html).toContain('aria-label="Move Grace down"');
+    expect(html).toMatch(/<button[^>]*aria-disabled="true"[^>]*aria-label="Move Grace down"/);
+    expect(html).toContain('aria-label="Remove Ada from ranking"');
+    expect(html).toContain('aria-label="Reset candidate ranking"');
+  });
+});

--- a/apps/mobile/src/components/candidate-ranking.tsx
+++ b/apps/mobile/src/components/candidate-ranking.tsx
@@ -1,0 +1,167 @@
+import type { Candidate } from '@/api/legacy-api';
+import { createRanking, moveCandidate, removeCandidate } from '@/features/ranking';
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+type CandidateRankingProps = {
+  candidates: readonly Candidate[];
+  orderedEntries: boolean;
+};
+
+export function CandidateRanking({ candidates, orderedEntries }: CandidateRankingProps) {
+  const [ranking, setRanking] = useState(() => createRanking(candidates, orderedEntries));
+
+  const reset = () => setRanking(createRanking(candidates, orderedEntries));
+
+  return (
+    <View>
+      <Text accessibilityLiveRegion="polite" style={styles.rankingStatus}>
+        {ranking.length} {ranking.length === 1 ? 'choice' : 'choices'} ranked
+      </Text>
+
+      <View style={styles.candidateList}>
+        {ranking.map((candidate, index) => {
+          const moveUpDisabled = index === 0;
+          const moveDownDisabled = index === ranking.length - 1;
+
+          return (
+            <View key={candidate.id} style={styles.candidateRow}>
+              <View accessibilityLabel={`Rank ${index + 1}`} style={styles.rankBadge}>
+                <Text style={styles.rankText}>{index + 1}</Text>
+              </View>
+              <Text style={styles.candidateName}>{candidate.name}</Text>
+              <View accessibilityLabel={`Ranking controls for ${candidate.name}`} style={styles.actions}>
+                <RankButton
+                  disabled={moveUpDisabled}
+                  label="Up"
+                  accessibilityLabel={`Move ${candidate.name} up`}
+                  onPress={() => setRanking((current) => moveCandidate(current, candidate.id, 'up'))}
+                />
+                <RankButton
+                  disabled={moveDownDisabled}
+                  label="Down"
+                  accessibilityLabel={`Move ${candidate.name} down`}
+                  onPress={() => setRanking((current) => moveCandidate(current, candidate.id, 'down'))}
+                />
+                <RankButton
+                  label="Remove"
+                  accessibilityLabel={`Remove ${candidate.name} from ranking`}
+                  destructive
+                  onPress={() => setRanking((current) => removeCandidate(current, candidate.id))}
+                />
+              </View>
+            </View>
+          );
+        })}
+      </View>
+
+      {ranking.length === 0 ? (
+        <Text accessibilityLiveRegion="polite" style={styles.emptyText}>
+          No choices are currently ranked. Reset to restore the ballot.
+        </Text>
+      ) : null}
+
+      <Pressable
+        accessibilityHint="Restores every choice and its initial ballot ordering"
+        accessibilityLabel="Reset candidate ranking"
+        accessibilityRole="button"
+        onPress={reset}
+        style={({ pressed }) => [styles.resetButton, pressed && styles.buttonPressed]}>
+        <Text style={styles.resetText}>Reset ranking</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+type RankButtonProps = {
+  accessibilityLabel: string;
+  destructive?: boolean;
+  disabled?: boolean;
+  label: string;
+  onPress: () => void;
+};
+
+function RankButton({
+  accessibilityLabel,
+  destructive = false,
+  disabled = false,
+  label,
+  onPress,
+}: RankButtonProps) {
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.actionButton,
+        destructive && styles.removeButton,
+        disabled && styles.actionDisabled,
+        pressed && !disabled && styles.buttonPressed,
+      ]}>
+      <Text style={[styles.actionText, destructive && styles.removeText, disabled && styles.disabledText]}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  rankingStatus: { color: '#40556b', fontSize: 13, marginTop: 12 },
+  candidateList: { gap: 10, marginTop: 10 },
+  candidateRow: {
+    alignItems: 'center',
+    backgroundColor: '#ffffff',
+    borderColor: '#d9e0e7',
+    borderRadius: 14,
+    borderWidth: 1,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+    padding: 12,
+  },
+  rankBadge: {
+    alignItems: 'center',
+    backgroundColor: '#12355b',
+    borderRadius: 18,
+    height: 36,
+    justifyContent: 'center',
+    width: 36,
+  },
+  rankText: { color: '#ffffff', fontSize: 15, fontWeight: '800' },
+  candidateName: { color: '#1f3143', flex: 1, fontSize: 17, fontWeight: '700', minWidth: 120 },
+  actions: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  actionButton: {
+    backgroundColor: '#e8eef4',
+    borderColor: '#b8c5d1',
+    borderRadius: 8,
+    borderWidth: 1,
+    minHeight: 40,
+    justifyContent: 'center',
+    paddingHorizontal: 11,
+    paddingVertical: 8,
+  },
+  actionText: { color: '#173b5e', fontSize: 14, fontWeight: '700' },
+  removeButton: { backgroundColor: '#fff1ef', borderColor: '#d8aaa5' },
+  removeText: { color: '#81261f' },
+  actionDisabled: { backgroundColor: '#f1f3f5', borderColor: '#dce1e5' },
+  disabledText: { color: '#8a959f' },
+  buttonPressed: { opacity: 0.72 },
+  emptyText: { color: '#6a5754', fontSize: 14, lineHeight: 20, marginTop: 14 },
+  resetButton: {
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    backgroundColor: '#ffffff',
+    borderColor: '#8ba0b4',
+    borderRadius: 10,
+    borderWidth: 1,
+    marginTop: 16,
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  resetText: { color: '#173b5e', fontSize: 15, fontWeight: '800' },
+});

--- a/apps/mobile/src/features/ranking.test.ts
+++ b/apps/mobile/src/features/ranking.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Candidate } from '@/api/legacy-api';
+
+import { createRanking, moveCandidate, removeCandidate, shuffleCandidates } from './ranking';
+
+const candidates: Candidate[] = [
+  { id: 1, name: 'Ada', image: '', hyperlink: '', color: null },
+  { id: 2, name: 'Grace', image: '', hyperlink: '', color: null },
+  { id: 3, name: 'Katherine', image: '', hyperlink: '', color: null },
+];
+
+describe('candidate ranking', () => {
+  it('preserves server order for ordered ballots without sharing the input array', () => {
+    const ranking = createRanking(candidates, true);
+
+    expect(ranking.map((candidate) => candidate.id)).toEqual([1, 2, 3]);
+    expect(ranking).not.toBe(candidates);
+  });
+
+  it('shuffles unordered ballots without mutating the server response', () => {
+    const ranking = shuffleCandidates(candidates, () => 0);
+
+    expect(ranking.map((candidate) => candidate.id)).toEqual([2, 3, 1]);
+    expect(candidates.map((candidate) => candidate.id)).toEqual([1, 2, 3]);
+  });
+
+  it('moves a candidate one rank at a time', () => {
+    expect(moveCandidate(candidates, 2, 'up').map((candidate) => candidate.id)).toEqual([2, 1, 3]);
+    expect(moveCandidate(candidates, 2, 'down').map((candidate) => candidate.id)).toEqual([1, 3, 2]);
+  });
+
+  it('does not wrap candidates past ranking boundaries', () => {
+    expect(moveCandidate(candidates, 1, 'up')).toEqual(candidates);
+    expect(moveCandidate(candidates, 3, 'down')).toEqual(candidates);
+  });
+
+  it('removes only the selected candidate', () => {
+    expect(removeCandidate(candidates, 2).map((candidate) => candidate.id)).toEqual([1, 3]);
+    expect(candidates).toHaveLength(3);
+  });
+});

--- a/apps/mobile/src/features/ranking.ts
+++ b/apps/mobile/src/features/ranking.ts
@@ -1,0 +1,50 @@
+import type { Candidate } from '@/api/legacy-api';
+
+export type RankDirection = 'up' | 'down';
+export type RandomSource = () => number;
+
+export function shuffleCandidates(
+  candidates: readonly Candidate[],
+  random: RandomSource = Math.random,
+): Candidate[] {
+  const shuffled = [...candidates];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1));
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+
+  return shuffled;
+}
+
+export function createRanking(
+  candidates: readonly Candidate[],
+  orderedEntries: boolean,
+  random: RandomSource = Math.random,
+): Candidate[] {
+  return orderedEntries ? [...candidates] : shuffleCandidates(candidates, random);
+}
+
+export function moveCandidate(
+  candidates: readonly Candidate[],
+  candidateId: number,
+  direction: RankDirection,
+): Candidate[] {
+  const currentIndex = candidates.findIndex((candidate) => candidate.id === candidateId);
+  const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1;
+
+  if (currentIndex < 0 || targetIndex < 0 || targetIndex >= candidates.length) {
+    return [...candidates];
+  }
+
+  const ranked = [...candidates];
+  [ranked[currentIndex], ranked[targetIndex]] = [ranked[targetIndex], ranked[currentIndex]];
+  return ranked;
+}
+
+export function removeCandidate(
+  candidates: readonly Candidate[],
+  candidateId: number,
+): Candidate[] {
+  return candidates.filter((candidate) => candidate.id !== candidateId);
+}

--- a/apps/mobile/vitest.config.mts
+++ b/apps/mobile/vitest.config.mts
@@ -6,10 +6,11 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'react-native': 'react-native-web',
     },
   },
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
## Summary

- add controlled candidate ranking state to the Expo ballot screen
- preserve ordered ballots and reshuffle unordered ballots on reset
- provide explicit accessible move-up, move-down, remove, and reset actions

## Verification

- mobile unit/component tests
- TypeScript and Expo lint
- Expo static export

<sub>Stack created with GitHub Stacks CLI.</sub>
