### PR TITLE
Use canonical ballot links

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -8,10 +8,11 @@ RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} -f
 RewriteRule ^.*$ - [L]
 
+RewriteRule ^/?ballot/[^/]+/?$ /index.html [L,QSA]
+
 RewriteRule ^/?([^/]+)/?$ #$1 [L,QSA]
 
 <Files 403.shtml>
 order allow,deny
 allow from all
 </Files>
-

--- a/src/js/ballot.js
+++ b/src/js/ballot.js
@@ -1,4 +1,5 @@
 import { dataFromObj } from './utils/helpers.js';
+import { canonicalBallotUrl } from './utils/ballot-links.js';
 
 var $s, $http, $sce, $timeout;
 
@@ -883,7 +884,7 @@ export function initBallot(scope, http, sce, timeout) {
   };
 
   $s.generateQRCode = function (shortCode) {
-    var url = 'https://rankedchoices.com/' + shortCode;
+    var url = canonicalBallotUrl(window.location.origin, shortCode);
     var el = document.getElementById('qrcode');
     el.innerHTML = '';
     new QRCode(el, url);

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -19,6 +19,12 @@ import {
   canSeeGraph,
   shouldUsePostCutoffPath
 } from './utils/rcvis-helpers.js';
+import {
+  canonicalBallotKey,
+  canonicalBallotPath,
+  canonicalBallotUrl,
+  isLegacyBallotPath
+} from './utils/ballot-links.js';
 
 /* Iframe auto-resize: hosted pages can postMessage their height */
 window.addEventListener('message', function (e) {
@@ -120,10 +126,16 @@ mainApp.controller('MainCtrl', [
 
     var getVoteParam = function (navigate) {
       var param = $loc.$$path.substr(1);
+      var canonicalKey = canonicalBallotKey($loc.$$path);
       let key;
 
       if (!param) {
         $s.navigate('home');
+      } else if (canonicalKey !== null) {
+        if (navigate && ($s.activeLink !== 'vote' || $s.shortcode !== canonicalKey)) {
+          $s.navigate('vote', canonicalKey);
+        }
+        return canonicalKey;
       } else if (param === 'results_json.html') {
         if (navigate) {
           $s.navigate('json');
@@ -238,6 +250,9 @@ mainApp.controller('MainCtrl', [
         showWeeks: false
       },
       origin: window.location.origin,
+      canonicalBallotUrl: function (key) {
+        return canonicalBallotUrl(window.location.origin, key);
+      },
       managedBallotFilter: function (ballot) {
         return ballot.isSecure == 1 || ballot.allowGrouping == 1;
       },
@@ -317,6 +332,10 @@ mainApp.controller('MainCtrl', [
       $http
         .get('/api/get-candidates.php?key=' + $s.shortcode + '&t=' + Date.now())
         .then(function (resp) {
+          if (typeof resp.data !== 'string' && isLegacyBallotPath($loc.$$path, $s.shortcode)) {
+            $loc.path(canonicalBallotPath($s.shortcode)).replace();
+          }
+
           if (resp.data && resp.data.status === 'closed') {
             if (!resp.data.resultsRelease) {
               $s.navigate('results', $s.shortcode);

--- a/src/js/utils/ballot-links.js
+++ b/src/js/utils/ballot-links.js
@@ -1,0 +1,22 @@
+export function canonicalBallotPath(key) {
+  return '/ballot/' + encodeURIComponent(String(key || '').trim());
+}
+
+export function canonicalBallotUrl(origin, key) {
+  return String(origin || '').replace(/\/+$/, '') + canonicalBallotPath(key);
+}
+
+export function canonicalBallotKey(pathname) {
+  var match = String(pathname || '').match(/^\/ballot\/([^/]+)\/?$/);
+  if (!match) return null;
+
+  try {
+    return decodeURIComponent(match[1]);
+  } catch (_error) {
+    return null;
+  }
+}
+
+export function isLegacyBallotPath(pathname, key) {
+  return String(pathname || '') === '/' + encodeURIComponent(String(key || '').trim());
+}

--- a/src/pages/create.html
+++ b/src/pages/create.html
@@ -29,7 +29,7 @@
         >
       </div>
       <div class="form-group">
-        <label>Shortcode (for link {{origin}}/{{ballot.key}})</label>
+        <label>Shortcode (for link {{canonicalBallotUrl(ballot.key)}})</label>
         <div class="input-group">
           <input
             name="key"
@@ -755,10 +755,10 @@
         <div class="col-sm-6">
           <h3>Thank you for creating a ballot!</h3>
           <h4>Send this url or QR code to people for voting:</h4>
-          <h4 class="text-success">{{origin}}/{{ballot.key}}</h4>
+          <h4 class="text-success">{{canonicalBallotUrl(ballot.key)}}</h4>
           <a
             ng-hide="ballot.isSecure"
-            href="{{origin}}/vote#{{ballot.key}}"
+            href="{{canonicalBallotUrl(ballot.key)}}"
             data-testid="vote-self-link"
             >Click here to vote yourself</a
           >

--- a/src/pages/custom-html-editor.html
+++ b/src/pages/custom-html-editor.html
@@ -6,7 +6,7 @@
           <h1>Custom Instructions: {{customHtmlBallot.name}}</h1>
           <h4>
             Shortcode: {{customHtmlBallot.key}} &nbsp; Voting URL:
-            {{origin}}/{{customHtmlBallot.key}}
+            {{canonicalBallotUrl(customHtmlBallot.key)}}
           </h4>
           <hr />
           <div id="quill-editor-container"><div id="quill-editor" style="height: 300px"></div></div>

--- a/src/pages/manage.html
+++ b/src/pages/manage.html
@@ -5,7 +5,8 @@
           >
           <h1>{{manageBallot.name}}</h1>
           <h4>
-            Shortcode: {{manageBallot.key}} &nbsp; Voting URL: {{origin}}/{{manageBallot.key}}
+            Shortcode: {{manageBallot.key}} &nbsp; Voting URL:
+            {{canonicalBallotUrl(manageBallot.key)}}
           </h4>
           <h4>
             Vote Cutoff: {{!manageBallot.voteCutoff ? 'never' :
@@ -289,7 +290,7 @@
                 <button ng-click="duplicateBallot(manageBallot)" class="btn btn-default btn-sm">
                   <i class="fa fa-clone"></i> Duplicate Ballot
                 </button>
-                <button ng-click="copyToClipboard(origin + '/' + manageBallot.key)" class="btn btn-default btn-sm">
+                <button ng-click="copyToClipboard(canonicalBallotUrl(manageBallot.key))" class="btn btn-default btn-sm">
                   Copy Voting URL
                 </button>
                 <button ng-click="transferBallot(manageBallot)" class="btn btn-default btn-sm">

--- a/src/pages/profile.html
+++ b/src/pages/profile.html
@@ -73,7 +73,7 @@
                     </a>
                   </li>
                   <li>
-                    <a href ng-click="copyToClipboard(origin + '/' + ballot.key)">
+                    <a href ng-click="copyToClipboard(canonicalBallotUrl(ballot.key))">
                       <i class="fa fa-link"></i> Copy URL
                     </a>
                   </li>

--- a/src/pages/results.html
+++ b/src/pages/results.html
@@ -200,7 +200,7 @@
           <i class="fa fa-print"></i> Print
         </button>
       </div>
-      <h4>Voting URL: {{origin}}/{{shortcode}}</h4>
+      <h4>Voting URL: {{canonicalBallotUrl(shortcode)}}</h4>
       <p
         ng-show="user.id && ballotCreatedBy == 'guest'"
         class="text-muted no-print"

--- a/src/pages/vote.html
+++ b/src/pages/vote.html
@@ -234,7 +234,7 @@
           </button>
         </form>
       </div>
-      <h4>Voting URL: {{origin}}/{{ballot.key}}</h4>
+      <h4>Voting URL: {{canonicalBallotUrl(ballot.key)}}</h4>
     </div>
     <div ng-show="thanks" data-testid="vote-thanks">
       <h1 data-testid="vote-ballot-title">Ballot: {{ballot.name}}</h1>
@@ -246,7 +246,7 @@
         Visit <a href="/results#{{shortcode}}">{{origin}}/results#{{ballot.key}}</a> after
         {{resultsReleaseFormatted}} to see the results
       </h5>
-      <h5>Voting URL: {{origin}}/{{ballot.key}}</h5>
+      <h5>Voting URL: {{canonicalBallotUrl(ballot.key)}}</h5>
       <p
         ng-show="user.id && ballotCreatedBy == 'guest'"
         class="text-muted"

--- a/test/ballot-links.test.js
+++ b/test/ballot-links.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalBallotKey,
+  canonicalBallotPath,
+  canonicalBallotUrl,
+  isLegacyBallotPath
+} from '@src/js/utils/ballot-links.js';
+
+describe('canonical ballot links', () => {
+  it('builds the canonical path and URL', () => {
+    expect(canonicalBallotPath(' pizza ')).toBe('/ballot/pizza');
+    expect(canonicalBallotUrl('https://rankedchoices.com/', 'pizza')).toBe(
+      'https://rankedchoices.com/ballot/pizza'
+    );
+  });
+
+  it('extracts a shortcode only from a canonical ballot path', () => {
+    expect(canonicalBallotKey('/ballot/pizza')).toBe('pizza');
+    expect(canonicalBallotKey('/ballot/pizza/')).toBe('pizza');
+    expect(canonicalBallotKey('/results')).toBeNull();
+    expect(canonicalBallotKey('/ballot/too/many')).toBeNull();
+  });
+
+  it('recognizes the legacy root-shortcode path', () => {
+    expect(isLegacyBallotPath('/pizza', 'pizza')).toBe(true);
+    expect(isLegacyBallotPath('/ballot/pizza', 'pizza')).toBe(false);
+  });
+});

--- a/test/e2e/happy-path.spec.js
+++ b/test/e2e/happy-path.spec.js
@@ -28,7 +28,12 @@ test('creates a ballot, casts a vote, and renders results', async ({ page }) => 
   await createView.getByTestId('entries-submit').click();
   await expect(createView.getByTestId('ballot-created')).toBeVisible();
 
-  await createView.getByTestId('vote-self-link').click();
+  const voteLink = await createView.getByTestId('vote-self-link').getAttribute('href');
+  const createdShortcode = new URL(voteLink).pathname.split('/').pop();
+  expect(new URL(voteLink).pathname).toBe(`/ballot/${createdShortcode}`);
+
+  await page.goto(`/${createdShortcode}`);
+  await expect(page).toHaveURL(new RegExp(`/ballot/${createdShortcode}$`));
   const voteView = page.getByTestId('vote-view');
   const ballotForm = voteView.getByTestId('vote-ballot-form');
   await expect(ballotForm.getByTestId('vote-ballot-title')).toContainText(ballotName);

--- a/test/e2e/mobile-voting.spec.js
+++ b/test/e2e/mobile-voting.spec.js
@@ -33,7 +33,7 @@ test('supports a mobile voting sanity flow without drag and drop', async ({ page
   await expect(createView.getByTestId('ballot-created')).toBeVisible();
 
   const voteLink = await createView.getByTestId('vote-self-link').getAttribute('href');
-  const ballotKey = new URL(voteLink).hash.slice(1);
+  const ballotKey = new URL(voteLink).pathname.split('/').pop();
 
   await createView.getByTestId('vote-self-link').click();
 


### PR DESCRIPTION
## Summary

- serve and recognize canonical /ballot/<key> website routes
- redirect valid legacy /<key> visits in-app after ballot lookup
- generate canonical voting URLs for QR codes, displays, and copy actions
- cover URL helpers and desktop/mobile browser flows

## Testing

- npm test (191 JavaScript tests, 217 PHP tests)
- npm run build
- npm run test:e2e -- test/e2e/happy-path.spec.js test/e2e/mobile-voting.spec.js
- git diff --check

## Stack

Depends on #73. This PR is the second layer and contains only the canonical-link delta relative to codex/rfc-maintainer-guidance.