### PR TITLE
Add native secure-code voting

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -5,7 +5,8 @@ shortcode lookup, ballot preview, and local candidate-ranking controls backed
 by the existing PHP API. Anonymous ballots can be submitted through the typed,
 idempotent v2 vote endpoint. Released votes are loaded through the public v2
 results contract and calculated locally by the pure `packages/rcv-core`
-TypeScript module. The app does not authenticate users yet.
+TypeScript module. Secure ballots can be submitted with an assigned voter
+code. The app does not authenticate users yet.
 
 ## Get started
 
@@ -67,6 +68,15 @@ submits, and waits for locally calculated results:
 ADB="$ANDROID_HOME/platform-tools/adb" npm run test:android:e2e
 ```
 
+To exercise a secure ballot, provide its shortcode and six-character code:
+
+```bash
+RCV_E2E_BALLOT_KEY=my-secure-ballot \
+RCV_E2E_VOTER_CODE=abcxyz \
+ADB="$ANDROID_HOME/platform-tools/adb" \
+npm run test:android:e2e
+```
+
 Expo Go is the default target. A development build can exercise the custom
 scheme with:
 
@@ -98,16 +108,15 @@ connectivity will be designed alongside the later web deployment decision.
 - typed normalization of the legacy `get-candidates.php` response
 - ballot lookup and accessible local candidate ranking
 - move-up, move-down, remove, and reset controls
-- idempotent anonymous vote submission with loading, retry, duplicate-device,
-  cutoff, and accepted states
+- idempotent anonymous and secure-code vote submission with loading, retry,
+  invalid/reused-code, duplicate-device, cutoff, and accepted states
 - local winner and round-by-round result rendering after an accepted vote
 - loading, closed, not-found, malformed-response, and network-error handling
 
-Name-required ballots, secure-code entry, grouping questions, authentication,
-production deployment, and domain association files remain unavailable. The
-first three belong to the later secure-voting/ballot-creation phase; this Phase
-1 client surfaces them as explicit unsupported states instead of submitting an
-incomplete vote.
+Name-required ballots, grouping questions, authentication, production
+deployment, and domain association files remain unavailable. The first two
+belong to the later secure-voting/ballot-creation phase; this client surfaces
+them as explicit unsupported states instead of submitting an incomplete vote.
 
 ## Expo resources
 

--- a/apps/mobile/scripts/android-phase1-e2e.mjs
+++ b/apps/mobile/scripts/android-phase1-e2e.mjs
@@ -2,11 +2,16 @@ import { execFileSync } from 'node:child_process';
 
 const adb = process.env.ADB ?? 'adb';
 const ballotKey = process.env.RCV_E2E_BALLOT_KEY ?? 'pizza';
+const voterCode = process.env.RCV_E2E_VOTER_CODE?.trim();
 const appPackage = process.env.RCV_E2E_APP_PACKAGE ?? 'host.exp.exponent';
 const incomingUrl =
   process.env.RCV_E2E_INCOMING_URL ??
   `exp://127.0.0.1:8081/--/ballot/${encodeURIComponent(ballotKey)}`;
 const coldStart = process.env.RCV_E2E_COLD_START !== '0';
+
+if (voterCode && !/^[A-Za-z0-9]{6}$/.test(voterCode)) {
+  throw new Error('RCV_E2E_VOTER_CODE must contain exactly six letters or digits.');
+}
 
 function run(...args) {
   return execFileSync(adb, args, { encoding: 'utf8' });
@@ -66,6 +71,18 @@ tapMatching(
 );
 waitFor(/content-desc="Move [^"]+ up"/, 'the updated candidate ranking');
 
+if (voterCode) {
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    xml = dump();
+    if (/content-desc="Voter code"/.test(xml)) break;
+    run('shell', 'input', 'swipe', '540', '2200', '540', '350', '400');
+  }
+  xml = dump();
+  tapMatching(xml, /content-desc="Voter code"[^>]*bounds="([^"]+)"/, 'the voter-code field');
+  run('shell', 'input', 'text', voterCode);
+  run('shell', 'input', 'keyevent', '4');
+}
+
 for (let attempt = 0; attempt < 6; attempt += 1) {
   xml = dump();
   if (/content-desc="Submit vote"/.test(xml)) break;
@@ -77,4 +94,4 @@ tapMatching(xml, /content-desc="Submit vote"[^>]*bounds="([^"]+)"/, 'the submit 
 waitFor(/text="Vote recorded"/, 'the accepted vote state');
 waitFor(/text="Current results"/, 'the locally calculated election results');
 
-console.log(`Phase 1 Android E2E passed for ${incomingUrl}`);
+console.log(`Android vote E2E passed for ${incomingUrl}`);

--- a/apps/mobile/src/api/v2-api.test.ts
+++ b/apps/mobile/src/api/v2-api.test.ts
@@ -7,6 +7,7 @@ const request = {
   requestId: '12345678-1234-4234-8234-123456789012',
   ranking: [3, 1, 2],
   fingerprint: 'installation-id',
+  voterCode: 'abcooi',
 };
 
 describe('V2ApiClient.submitVote', () => {
@@ -52,6 +53,26 @@ describe('V2ApiClient.submitVote', () => {
       code: 'duplicate_device',
       retryable: false,
       status: 409,
+    });
+  });
+
+  it('preserves invalid voter-code errors', async () => {
+    const client = new V2ApiClient({
+      baseUrl: 'https://example.test/api',
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            data: null,
+            error: { code: 'invalid_voter_code', message: 'Code not accepted.' },
+          }),
+          { status: 403 },
+        ),
+    });
+
+    await expect(client.submitVote(request)).rejects.toMatchObject({
+      code: 'invalid_voter_code',
+      retryable: false,
+      status: 403,
     });
   });
 

--- a/apps/mobile/src/api/v2-api.ts
+++ b/apps/mobile/src/api/v2-api.ts
@@ -3,6 +3,7 @@ export type SubmitVoteRequest = {
   requestId: string;
   ranking: number[];
   fingerprint?: string;
+  voterCode?: string;
 };
 
 export type SubmitVoteResult = {
@@ -30,6 +31,7 @@ export type V2ApiErrorCode =
   | 'voting_closed'
   | 'voter_name_required'
   | 'secure_code_required'
+  | 'invalid_voter_code'
   | 'group_answers_required'
   | 'fingerprint_required'
   | 'duplicate_device'
@@ -73,6 +75,7 @@ function isKnownErrorCode(value: unknown): value is V2ApiErrorCode {
       'voting_closed',
       'voter_name_required',
       'secure_code_required',
+      'invalid_voter_code',
       'group_answers_required',
       'fingerprint_required',
       'duplicate_device',

--- a/apps/mobile/src/components/vote-submission.test.tsx
+++ b/apps/mobile/src/components/vote-submission.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Ballot, Candidate } from '@/api/legacy-api';
+
+import { VoteSubmission } from './vote-submission';
+
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'test-request-id' }));
+
+const ballot: Ballot = {
+  id: 1,
+  key: 'secure-ballot',
+  name: 'Secure ballot',
+  positions: 1,
+  register: 0,
+  resultsRelease: null,
+  voteCutoff: null,
+  hideNames: false,
+  hideDetails: false,
+  allowCustom: false,
+  showGraph: false,
+  kickbackUrl: null,
+  iframeUrl: null,
+  oneDeviceOneVote: false,
+  isSecure: true,
+  orderedEntries: true,
+  allowGrouping: false,
+  createdBy: 'guest',
+};
+
+const ranking: Candidate[] = [
+  { id: 1, name: 'Ada', image: '', hyperlink: '', color: null },
+];
+
+describe('VoteSubmission', () => {
+  it('renders an accessible code field and blocks submission until it is complete', () => {
+    const html = renderToStaticMarkup(
+      <VoteSubmission ballot={ballot} onAccepted={() => undefined} ranking={ranking} />,
+    );
+
+    expect(html).toContain('aria-label="Voter code"');
+    expect(html).toContain('Enter the six-character voter code');
+    expect(html).toMatch(/<button[^>]*aria-disabled="true"[^>]*aria-label="Submit vote"/);
+  });
+});

--- a/apps/mobile/src/components/vote-submission.tsx
+++ b/apps/mobile/src/components/vote-submission.tsx
@@ -6,18 +6,19 @@ import {
   formatCutoffCountdown,
   getOrCreateVoteRequest,
   getVoteBlocker,
+  normalizeVoterCode,
   type PendingVoteRequest,
 } from '@/features/vote-submission';
 import { loadInstallationId } from '@/utils/installation-id';
 import * as Crypto from 'expo-crypto';
 import { useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 
 type SubmissionState =
-  | { status: 'idle'; rankingKey: string }
-  | { status: 'submitting'; rankingKey: string }
-  | { status: 'accepted'; rankingKey: string; replayed: boolean; voteId: number }
-  | { status: 'error'; rankingKey: string; error: V2ApiError };
+  | { status: 'idle'; submissionKey: string }
+  | { status: 'submitting'; submissionKey: string }
+  | { status: 'accepted'; submissionKey: string; replayed: boolean; voteId: number }
+  | { status: 'error'; submissionKey: string; error: V2ApiError };
 
 type VoteSubmissionProps = {
   ballot: Ballot;
@@ -29,10 +30,16 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
   const client = useMemo(() => createV2ApiClient(), []);
   const [now, setNow] = useState(() => Date.now());
   const [request, setRequest] = useState<PendingVoteRequest | null>(null);
+  const [voterCode, setVoterCode] = useState('');
   const rankingKey = ranking.map((candidate) => candidate.id).join(',');
-  const [state, setState] = useState<SubmissionState>({ status: 'idle', rankingKey });
+  const normalizedVoterCode = normalizeVoterCode(voterCode);
+  const ballotRankingKey = `${ballot.key}|${rankingKey}`;
+  const submissionKey = ballot.isSecure
+    ? `${ballotRankingKey}|${normalizedVoterCode}`
+    : ballotRankingKey;
+  const [state, setState] = useState<SubmissionState>({ status: 'idle', submissionKey });
   const currentState: SubmissionState =
-    state.rankingKey === rankingKey ? state : { status: 'idle', rankingKey };
+    state.submissionKey === submissionKey ? state : { status: 'idle', submissionKey };
 
   useEffect(() => {
     if (!ballot.voteCutoff) return;
@@ -40,16 +47,16 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
     return () => clearInterval(timer);
   }, [ballot.voteCutoff]);
 
-  const blocker = getVoteBlocker(ballot, ranking.length, now);
+  const blocker = getVoteBlocker(ballot, ranking.length, now, voterCode);
   const cutoffMessage = formatCutoffCountdown(ballot.voteCutoff, now);
 
   const submit = async () => {
     if (blocker || currentState.status === 'submitting' || currentState.status === 'accepted') return;
 
-    const activeRequest = getOrCreateVoteRequest(request, rankingKey, Crypto.randomUUID);
+    const activeRequest = getOrCreateVoteRequest(request, submissionKey, Crypto.randomUUID);
     const activeRequestId = activeRequest.requestId;
     setRequest(activeRequest);
-    setState({ status: 'submitting', rankingKey });
+    setState({ status: 'submitting', submissionKey });
 
     try {
       const fingerprint = ballot.oneDeviceOneVote ? await loadInstallationId() : undefined;
@@ -58,10 +65,11 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
         requestId: activeRequestId,
         ranking: ranking.map((candidate) => candidate.id),
         fingerprint,
+        voterCode: ballot.isSecure ? normalizedVoterCode : undefined,
       });
       setState({
         status: 'accepted',
-        rankingKey,
+        submissionKey,
         replayed: result.replayed,
         voteId: result.voteId,
       });
@@ -69,7 +77,7 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
     } catch (error) {
       setState({
         status: 'error',
-        rankingKey,
+        submissionKey,
         error:
           error instanceof V2ApiError
             ? error
@@ -97,6 +105,25 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
         </Text>
       ) : null}
 
+      {ballot.isSecure ? (
+        <View style={styles.codeField}>
+          <Text style={styles.codeLabel}>Voter code</Text>
+          <TextInput
+            accessibilityLabel="Voter code"
+            autoCapitalize="characters"
+            autoComplete="one-time-code"
+            autoCorrect={false}
+            editable={currentState.status !== 'submitting'}
+            maxLength={6}
+            onChangeText={(value) => setVoterCode(value.replace(/\s/g, ''))}
+            placeholder="Six-character code"
+            style={styles.codeInput}
+            textContentType="oneTimeCode"
+            value={voterCode}
+          />
+        </View>
+      ) : null}
+
       {blocker ? (
         <Text accessibilityLiveRegion="polite" style={styles.blockerNotice}>
           {blockerMessage(blocker)}
@@ -106,7 +133,11 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
       {currentState.status === 'error' ? (
         <View accessibilityLiveRegion="assertive" style={styles.errorCard}>
           <Text style={styles.errorTitle}>
-            {currentState.error.code === 'duplicate_device' ? 'Already voted' : 'Vote not recorded'}
+            {currentState.error.code === 'duplicate_device'
+              ? 'Already voted'
+              : currentState.error.code === 'invalid_voter_code'
+                ? 'Code not accepted'
+                : 'Vote not recorded'}
           </Text>
           <Text style={styles.errorText}>{currentState.error.message}</Text>
           {currentState.error.retryable ? (
@@ -164,6 +195,20 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     marginBottom: 12,
     padding: 12,
+  },
+  codeField: { marginBottom: 12 },
+  codeLabel: { color: '#263b33', fontSize: 14, fontWeight: '700', marginBottom: 6 },
+  codeInput: {
+    backgroundColor: '#ffffff',
+    borderColor: '#8aa097',
+    borderRadius: 10,
+    borderWidth: 1,
+    color: '#172b23',
+    fontSize: 18,
+    letterSpacing: 2,
+    minHeight: 48,
+    paddingHorizontal: 13,
+    paddingVertical: 10,
   },
   errorCard: { backgroundColor: '#fff1ef', borderRadius: 12, marginBottom: 12, padding: 14 },
   errorTitle: { color: '#81261f', fontSize: 17, fontWeight: '800' },

--- a/apps/mobile/src/features/vote-submission.test.ts
+++ b/apps/mobile/src/features/vote-submission.test.ts
@@ -7,6 +7,7 @@ import {
   formatCutoffCountdown,
   getOrCreateVoteRequest,
   getVoteBlocker,
+  normalizeVoterCode,
   parseUtcTimestamp,
 } from './vote-submission';
 
@@ -33,13 +34,17 @@ const ballot: Ballot = {
 
 describe('vote submission states', () => {
   it('reuses a request ID only while retrying the same ranking', () => {
-    const pending = { rankingKey: '1,2', requestId: 'original-id' };
+    const pending = { submissionKey: '1,2|codeaa', requestId: 'original-id' };
 
-    expect(getOrCreateVoteRequest(pending, '1,2', () => 'new-id')).toBe(pending);
-    expect(getOrCreateVoteRequest(pending, '2,1', () => 'new-id')).toEqual({
-      rankingKey: '2,1',
+    expect(getOrCreateVoteRequest(pending, '1,2|codeaa', () => 'new-id')).toBe(pending);
+    expect(getOrCreateVoteRequest(pending, '1,2|codebb', () => 'new-id')).toEqual({
+      submissionKey: '1,2|codebb',
       requestId: 'new-id',
     });
+  });
+
+  it('normalizes voter-code case and ambiguous characters', () => {
+    expect(normalizeVoterCode(' AbC001 ')).toBe('abcooi');
   });
 
   it('parses legacy database timestamps as UTC', () => {
@@ -52,7 +57,8 @@ describe('vote submission states', () => {
 
     expect(getVoteBlocker({ ...ballot, voteCutoff: '2026-08-16 11:59:59' }, 2, now)).toBe('closed');
     expect(getVoteBlocker({ ...ballot, register: 1 }, 2, now)).toBe('voter_name_required');
-    expect(getVoteBlocker({ ...ballot, isSecure: true }, 2, now)).toBe('secure_code_required');
+    expect(getVoteBlocker({ ...ballot, isSecure: true }, 2, now, 'short')).toBe('secure_code_required');
+    expect(getVoteBlocker({ ...ballot, isSecure: true }, 2, now, 'ABC001')).toBeNull();
     expect(getVoteBlocker({ ...ballot, allowGrouping: true }, 2, now)).toBe('group_answers_required');
     expect(getVoteBlocker(ballot, 0, now)).toBe('empty_ranking');
     expect(getVoteBlocker(ballot, 2, now)).toBeNull();

--- a/apps/mobile/src/features/vote-submission.ts
+++ b/apps/mobile/src/features/vote-submission.ts
@@ -8,16 +8,22 @@ export type VoteBlocker =
   | 'group_answers_required';
 
 export type PendingVoteRequest = {
-  rankingKey: string;
+  submissionKey: string;
   requestId: string;
 };
 
 export function getOrCreateVoteRequest(
   pending: PendingVoteRequest | null,
-  rankingKey: string,
+  submissionKey: string,
   createId: () => string,
 ): PendingVoteRequest {
-  return pending?.rankingKey === rankingKey ? pending : { rankingKey, requestId: createId() };
+  return pending?.submissionKey === submissionKey
+    ? pending
+    : { submissionKey, requestId: createId() };
+}
+
+export function normalizeVoterCode(value: string): string {
+  return value.trim().toLowerCase().replaceAll('0', 'o').replaceAll('1', 'i');
 }
 
 export function parseUtcTimestamp(value: string | null): number | null {
@@ -33,11 +39,12 @@ export function getVoteBlocker(
   ballot: Ballot,
   rankingCount: number,
   now = Date.now(),
+  voterCode = '',
 ): VoteBlocker | null {
   const cutoff = parseUtcTimestamp(ballot.voteCutoff);
   if (cutoff !== null && now >= cutoff) return 'closed';
   if (ballot.register === 1) return 'voter_name_required';
-  if (ballot.isSecure) return 'secure_code_required';
+  if (ballot.isSecure && normalizeVoterCode(voterCode).length !== 6) return 'secure_code_required';
   if (ballot.allowGrouping) return 'group_answers_required';
   if (rankingCount === 0) return 'empty_ranking';
   return null;
@@ -52,7 +59,7 @@ export function blockerMessage(blocker: VoteBlocker): string {
     case 'voter_name_required':
       return 'This ballot requires a voter name and is not available in the anonymous flow.';
     case 'secure_code_required':
-      return 'This ballot requires a voter code. Secure-code entry is not available in the anonymous flow.';
+      return 'Enter the six-character voter code to submit this ballot.';
     case 'group_answers_required':
       return 'This ballot requires voter questions that are not available in the anonymous flow.';
   }

--- a/docs/expo-migration-rfc.md
+++ b/docs/expo-migration-rfc.md
@@ -360,6 +360,13 @@ and Android, including failure recovery, without regressing the website.
 Exit criteria: a guest can create and share a basic ballot; secure ballots can
 be voted from native when supplied a valid code.
 
+Secure-code voting can ship as an independent first slice while guest-ballot
+recovery remains unresolved. The native request carries the normalized code;
+the server verifies that it is assigned to the ballot, serializes redemption,
+stores the code in the legacy vote-name field, and preserves idempotent replay
+for an identical request. Invalid and previously used codes intentionally
+share one nonspecific client error.
+
 ### Phase 3 — authentication and management
 
 - Implement server-side password hashing, migrate legacy hashes on successful
@@ -445,7 +452,8 @@ canonical ballot URLs, the high-level legacy-password approach, launch
 telemetry, and web-only features. The following details remain intentionally
 deferred:
 
-- Define guest ballot recovery and claim behavior before Phase 2 begins.
+- Define guest ballot recovery and claim behavior before native guest creation
+  and owner workflows begin.
 - Define the legacy-password migration window, reset deadline, rate limits, and
   endpoint-removal plan during the Phase 3 authentication design.
 - Decide whether later product usage warrants privacy-minimizing product

--- a/src/api/v2/README.md
+++ b/src/api/v2/README.md
@@ -21,24 +21,29 @@ Version 2 endpoints use one JSON envelope for success and failure:
 
 ## `POST /api/v2/votes.php`
 
-The Phase 1 anonymous-vote endpoint accepts:
+The vote endpoint accepts anonymous and secure-code ballots:
 
 ```json
 {
   "key": "ballot-shortcode",
   "requestId": "client_generated_16_to_64_chars",
   "ranking": [42, 17, 23],
-  "fingerprint": "optional-installation-identifier"
+  "fingerprint": "optional-installation-identifier",
+  "voterCode": "optional-six-character-code"
 }
 ```
 
 Candidate names and the ballot ID are derived on the server. A request ID is
-scoped to its ballot and can be safely retried with the same ranking. Reusing
-it with a different ranking returns `idempotency_conflict`.
+scoped to its ballot and can be safely retried with the same ranking and voter
+code. Reusing it with a different ranking or code returns
+`idempotency_conflict`.
 
-This endpoint intentionally stops at the Phase 1 anonymous flow. Ballots that
-require a voter name, voter code, or grouping answers return typed states for
-the client; collecting those values remains Phase 2 work.
+Secure codes are normalized to lowercase, with `0` treated as `o` and `1`
+treated as `i`, matching the legacy voting flow. Each assigned code can record
+one vote. Missing codes return `secure_code_required`; unassigned or previously
+used codes return the deliberately nonspecific `invalid_voter_code` response.
+Ballots that require a voter name or grouping answers still return typed
+unsupported states for the client.
 
 ## `GET /api/v2/results.php?key=ballot-shortcode`
 

--- a/src/api/v2/votes.php
+++ b/src/api/v2/votes.php
@@ -58,6 +58,16 @@ function normalizeRanking($value): ?array
     return $ids;
 }
 
+function normalizeVoterCode($value): ?string
+{
+    if (!is_string($value)) {
+        return null;
+    }
+
+    $code = strtr(strtolower(trim($value)), '01', 'oi');
+    return strlen($code) === 6 ? $code : null;
+}
+
 function findIdempotentVote(PDO $dbh, int $ballotId, string $requestId): ?array
 {
     $statement = $dbh->prepare(
@@ -111,7 +121,17 @@ if (!$ballot) {
 }
 
 $ballotId = (int) $ballot['id'];
-$requestHash = hash('sha256', json_encode(['ranking' => $ranking], JSON_UNESCAPED_SLASHES));
+$isSecure = (int) $ballot['isSecure'] === 1;
+$voterCode = $isSecure ? normalizeVoterCode($input['voterCode'] ?? null) : null;
+if ($isSecure && $voterCode === null) {
+    fail(422, 'secure_code_required', 'Enter the six-character voter code.');
+}
+
+$requestPayload = ['ranking' => $ranking];
+if ($isSecure) {
+    $requestPayload['voterCode'] = $voterCode;
+}
+$requestHash = hash('sha256', json_encode($requestPayload, JSON_UNESCAPED_SLASHES));
 $existingVote = findIdempotentVote($dbh, $ballotId, $requestId);
 if ($existingVote) {
     if (!hash_equals((string) $existingVote['requestHash'], $requestHash)) {
@@ -130,10 +150,6 @@ if ($ballot['voteCutoff'] !== null && $ballot['voteCutoff'] < gmdate('Y-m-d H:i:
 
 if ((int) $ballot['register'] === 1) {
     fail(409, 'voter_name_required', 'This ballot requires a voter name, which is not supported in the anonymous flow.');
-}
-
-if ((int) $ballot['isSecure'] === 1) {
-    fail(409, 'secure_code_required', 'This ballot requires a voter code.');
 }
 
 if ((int) $ballot['allowGrouping'] === 1) {
@@ -178,25 +194,91 @@ if (count($candidateNames) !== count($ranking)) {
 $voteNames = array_map(fn (int $candidateId): string => $candidateNames[$candidateId], $ranking);
 $voteJson = json_encode($voteNames, JSON_UNESCAPED_SLASHES);
 $voteIds = implode(',', $ranking);
+$secureTransaction = false;
 
 try {
+    if ($isSecure) {
+        $dbh->beginTransaction();
+        $secureTransaction = true;
+
+        // Lock the ballot-code assignment until the vote is recorded. This
+        // serializes concurrent attempts to redeem the same code even though
+        // the production votes table is still MyISAM.
+        $lockSuffix = $dbh->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql' ? ' FOR UPDATE' : '';
+        $codeStatement = $dbh->prepare(
+            'SELECT bc.random_code_id FROM ballot_codes bc '
+            . 'JOIN random_codes rc ON rc.id = bc.random_code_id '
+            . 'WHERE bc.ballot_id = :ballotId AND rc.code = :voterCode LIMIT 1'
+            . $lockSuffix
+        );
+        $codeStatement->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
+        $codeStatement->bindValue(':voterCode', $voterCode, PDO::PARAM_STR);
+        $codeStatement->execute();
+        if (!$codeStatement->fetch(PDO::FETCH_ASSOC)) {
+            $dbh->rollBack();
+            $secureTransaction = false;
+            fail(403, 'invalid_voter_code', 'The voter code is invalid or has already been used.');
+        }
+
+        // A concurrent retry may have completed while this request waited for
+        // the code lock, so repeat the idempotency check before rejecting a
+        // code that now appears used.
+        $existingVote = findIdempotentVote($dbh, $ballotId, $requestId);
+        if ($existingVote) {
+            $dbh->commit();
+            $secureTransaction = false;
+            if (!hash_equals((string) $existingVote['requestHash'], $requestHash)) {
+                fail(409, 'idempotency_conflict', 'This request ID was already used for a different vote.');
+            }
+            respond(200, [
+                'status' => 'accepted',
+                'voteId' => (int) $existingVote['vote_id'],
+                'replayed' => true,
+            ], null);
+        }
+
+        $usedCodeStatement = $dbh->prepare(
+            'SELECT vote_id FROM votes WHERE ballotId = :ballotId AND name = :voterCode LIMIT 1'
+        );
+        $usedCodeStatement->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
+        $usedCodeStatement->bindValue(':voterCode', $voterCode, PDO::PARAM_STR);
+        $usedCodeStatement->execute();
+        if ($usedCodeStatement->fetch()) {
+            $dbh->rollBack();
+            $secureTransaction = false;
+            fail(403, 'invalid_voter_code', 'The voter code is invalid or has already been used.');
+        }
+    }
+
     $insert = $dbh->prepare(
         'INSERT INTO votes '
         . '(ballotId, date_created, vote, voteIds, ipAddress, name, fingerprint, group_answers, requestKey, requestHash) '
-        . 'VALUES (:ballotId, UTC_TIMESTAMP(), :vote, :voteIds, :ipAddress, \'\', :fingerprint, NULL, :requestKey, :requestHash)'
+        . 'VALUES (:ballotId, UTC_TIMESTAMP(), :vote, :voteIds, :ipAddress, :voterName, :fingerprint, NULL, :requestKey, :requestHash)'
     );
     $insert->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
     $insert->bindValue(':vote', $voteJson, PDO::PARAM_STR);
     $insert->bindValue(':voteIds', $voteIds, PDO::PARAM_STR);
     $insert->bindValue(':ipAddress', $_SERVER['REMOTE_ADDR'] ?? '', PDO::PARAM_STR);
+    $insert->bindValue(':voterName', $voterCode ?? '', PDO::PARAM_STR);
     $insert->bindValue(':fingerprint', $fingerprint, PDO::PARAM_STR);
     $insert->bindValue(':requestKey', $requestId, PDO::PARAM_STR);
     $insert->bindValue(':requestHash', $requestHash, PDO::PARAM_STR);
     $insert->execute();
     $voteId = (int) $dbh->lastInsertId();
+    if ($secureTransaction) {
+        $dbh->commit();
+        $secureTransaction = false;
+    }
 } catch (PDOException $exception) {
+    if ($secureTransaction && $dbh->inTransaction()) {
+        $dbh->rollBack();
+        $secureTransaction = false;
+    }
     $existingVote = findIdempotentVote($dbh, $ballotId, $requestId);
-    if (!$existingVote || !hash_equals((string) $existingVote['requestHash'], $requestHash)) {
+    if ($existingVote && !hash_equals((string) $existingVote['requestHash'], $requestHash)) {
+        fail(409, 'idempotency_conflict', 'This request ID was already used for a different vote.');
+    }
+    if (!$existingVote) {
         error_log('v2 vote insert failed: ' . $exception->getMessage());
         fail(500, 'server_error', 'The vote could not be recorded.');
     }

--- a/test/contract/live-php-api.test.js
+++ b/test/contract/live-php-api.test.js
@@ -39,7 +39,7 @@ async function requestApi(method, endpoint, { query, body } = {}) {
   };
 }
 
-async function createBallot() {
+async function createBallot({ isSecure = false, codeCount = 0 } = {}) {
   const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const key = `contract-${uniqueId}`;
   const createdBy = `contract-test-${uniqueId}`;
@@ -52,7 +52,9 @@ async function createBallot() {
       positions: '1',
       createdBy,
       sqlVoteCutoff: '2099-12-31 23:59:59',
-      sqlResultsRelease: '2099-12-31 23:59:59'
+      sqlResultsRelease: '2099-12-31 23:59:59',
+      isSecure,
+      codeCount
     }
   });
 
@@ -147,6 +149,42 @@ describe('live PHP API contracts', () => {
     });
   });
 
+  it('redeems a secure voter code once while preserving idempotent retries', async () => {
+    const ballot = await createBallot({ isSecure: true, codeCount: 1 });
+    const candidates = await requestApi('GET', 'get-candidates.php', {
+      query: { key: ballot.key }
+    });
+    const ranking = candidates.json.candidates.map((candidate) => Number(candidate.entry_id));
+    const body = {
+      key: ballot.key,
+      requestId: `secure_contract_${Date.now()}`,
+      ranking,
+      voterCode: 'E2EABC'
+    };
+
+    const first = await requestApi('POST', 'v2/votes.php', { body });
+    const replay = await requestApi('POST', 'v2/votes.php', { body });
+    const reused = await requestApi('POST', 'v2/votes.php', {
+      body: { ...body, requestId: `secure_reuse_${Date.now()}` }
+    });
+
+    expect(first.status).toBe(201);
+    expect(first.json).toMatchObject({
+      data: { status: 'accepted', replayed: false },
+      error: null
+    });
+    expect(replay.status).toBe(200);
+    expect(replay.json).toEqual({
+      data: { ...first.json.data, replayed: true },
+      error: null
+    });
+    expect(reused.status).toBe(403);
+    expect(reused.json).toMatchObject({
+      data: null,
+      error: { code: 'invalid_voter_code' }
+    });
+  });
+
   it('creates a ballot, returns candidates, records a vote, and returns results', async () => {
     const ballot = await createBallot();
 
@@ -159,7 +197,7 @@ describe('live PHP API contracts', () => {
         id: ballot.ballotId,
         key: ballot.key,
         name: ballot.ballotName,
-        positions: '1'
+        positions: 1
       }),
       candidates: expect.arrayContaining([
         expect.objectContaining({ candidate: 'Alpha' }),

--- a/test/e2e/db.mjs
+++ b/test/e2e/db.mjs
@@ -77,6 +77,7 @@ GRANT ALL PRIVILEGES ON ${dbName}.* TO ${sqlString(config.appUser)}@${sqlString(
 FLUSH PRIVILEGES;
 USE ${dbName};
 ${tables}
+INSERT INTO random_codes (code) VALUES ('e2eabc');
 `);
 }
 

--- a/test/php/V2VoteTest.php
+++ b/test/php/V2VoteTest.php
@@ -62,6 +62,93 @@ class V2VoteTest extends ApiTestCase
         $this->assertSame(1, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
     }
 
+    public function testRecordsASecureVoteUsingTheNormalizedVoterCode(): void
+    {
+        $key = 'secure-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'isSecure' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice', 'Bob']);
+        $this->seedVoterCode($ballotId, 'abcooi');
+
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'voterCode' => ' ABC001 ',
+        ]));
+
+        $this->assertSame('accepted', $result['body']['data']['status']);
+        $this->assertFalse($result['body']['data']['replayed']);
+        $this->assertNull($result['body']['error']);
+        $this->assertSame('abcooi', $this->db->query('SELECT name FROM votes')->fetchColumn());
+    }
+
+    public function testRejectsAnUnassignedSecureVoterCode(): void
+    {
+        $key = 'secure-invalid-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'isSecure' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice']);
+        $this->seedRandomCode('unused');
+
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'voterCode' => 'unused',
+        ]));
+
+        $this->assertSame('invalid_voter_code', $result['body']['error']['code']);
+        $this->assertSame(0, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
+    }
+
+    public function testRejectsASecondVoteUsingTheSameSecureCode(): void
+    {
+        $key = 'secure-used-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'isSecure' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice', 'Bob']);
+        $this->seedVoterCode($ballotId, 'usemeq');
+
+        $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'voterCode' => 'usemeq',
+        ]));
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, array_reverse($entryIds), [
+            'requestId' => 'different_request_12345',
+            'voterCode' => 'usemeq',
+        ]));
+
+        $this->assertSame('invalid_voter_code', $result['body']['error']['code']);
+        $this->assertSame(1, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
+    }
+
+    public function testReplaysASecureVoteWithTheSameRequestAndCode(): void
+    {
+        $key = 'secure-replay-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'isSecure' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice']);
+        $this->seedVoterCode($ballotId, 'replay');
+        $request = $this->validRequest($key, $entryIds, ['voterCode' => 'replay']);
+
+        $first = $this->callApi('v2/votes.php', $request);
+        $second = $this->callApi('v2/votes.php', $request);
+
+        $this->assertFalse($first['body']['data']['replayed']);
+        $this->assertTrue($second['body']['data']['replayed']);
+        $this->assertSame($first['body']['data']['voteId'], $second['body']['data']['voteId']);
+        $this->assertSame(1, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
+    }
+
+    public function testRejectsAReusedSecureRequestIdWithADifferentCode(): void
+    {
+        $key = 'secure-conflict-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'isSecure' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice']);
+        $this->seedVoterCode($ballotId, 'firstx');
+        $this->seedVoterCode($ballotId, 'second');
+
+        $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'voterCode' => 'firstx',
+        ]));
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'voterCode' => 'second',
+        ]));
+
+        $this->assertSame('idempotency_conflict', $result['body']['error']['code']);
+        $this->assertSame(1, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
+    }
+
     public function testRejectsInvalidRequestFields(): void
     {
         $result = $this->callApi('v2/votes.php', [


### PR DESCRIPTION
Stacked on #74 as layer 3 of native stack #76.

## Summary
- accept assigned six-character voter codes in the v2 vote endpoint with legacy-compatible case and 0/1 normalization
- serialize code redemption so the same code cannot record two votes, while preserving safe idempotent retries
- add accessible native code entry, typed invalid/reused-code states, and code-aware request IDs
- extend the API/mobile documentation, RFC, live MySQL contract fixture, and Android device scenario

## Verification
- npm test: 191 Vitest tests and 222 PHPUnit tests (529 assertions)
- npm run build
- mobile npm test: 35 tests
- mobile npm run typecheck
- mobile npm run lint
- mobile npx expo export --platform web
- npm run test:api-contract: 5 live PHP/MySQL contract tests
- Android API 36 emulator E2E: canonical link -> reorder -> enter secure code -> submit -> local results
- database assertion: exactly one vote stored with normalized voter code
- PHP and Node syntax checks

All GitHub test and mobile checks are green.