### PR TITLE
Add native grouping-question voting

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -6,7 +6,9 @@ by the existing PHP API. Anonymous ballots can be submitted through the typed,
 idempotent v2 vote endpoint. Released votes are loaded through the public v2
 results contract and calculated locally by the pure `packages/rcv-core`
 TypeScript module. Secure ballots can be submitted with an assigned voter
-code. The app does not authenticate users yet.
+code. Ballots with voter grouping enabled render and validate their select,
+checkbox, and text questions before submission. The app does not authenticate
+users yet.
 
 ## Get started
 
@@ -77,12 +79,22 @@ ADB="$ANDROID_HOME/platform-tools/adb" \
 npm run test:android:e2e
 ```
 
+For a grouped ballot, pass one visible select-option label so the scenario
+answers the question before ranking and submission:
+
+```bash
+RCV_E2E_BALLOT_KEY=my-grouped-ballot \
+RCV_E2E_GROUP_OPTION_LABEL=North \
+ADB="$ANDROID_HOME/platform-tools/adb" \
+npm run test:android:e2e
+```
+
 Expo Go is the default target. A development build can exercise the custom
 scheme with:
 
 ```bash
 RCV_E2E_APP_PACKAGE=com.rankedchoices.dev \
-RCV_E2E_INCOMING_URL=rankedchoices://ballot/pizza \
+RCV_E2E_INCOMING_URL=rankedchoices:///ballot/pizza \
 RCV_E2E_COLD_START=0 \
 npm run test:android:e2e
 ```
@@ -110,13 +122,14 @@ connectivity will be designed alongside the later web deployment decision.
 - move-up, move-down, remove, and reset controls
 - idempotent anonymous and secure-code vote submission with loading, retry,
   invalid/reused-code, duplicate-device, cutoff, and accepted states
+- accessible select, checkbox, and text grouping questions with client and
+  server validation
 - local winner and round-by-round result rendering after an accepted vote
 - loading, closed, not-found, malformed-response, and network-error handling
 
-Name-required ballots, grouping questions, authentication, production
-deployment, and domain association files remain unavailable. The first two
-belong to the later secure-voting/ballot-creation phase; this client surfaces
-them as explicit unsupported states instead of submitting an incomplete vote.
+Name-required ballots, authentication, production deployment, and domain
+association files remain unavailable. Name-required ballots surface an
+explicit unsupported state instead of submitting an incomplete vote.
 
 ## Expo resources
 

--- a/apps/mobile/scripts/android-phase1-e2e.mjs
+++ b/apps/mobile/scripts/android-phase1-e2e.mjs
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 const adb = process.env.ADB ?? 'adb';
 const ballotKey = process.env.RCV_E2E_BALLOT_KEY ?? 'pizza';
 const voterCode = process.env.RCV_E2E_VOTER_CODE?.trim();
+const groupOptionLabel = process.env.RCV_E2E_GROUP_OPTION_LABEL?.trim();
 const appPackage = process.env.RCV_E2E_APP_PACKAGE ?? 'host.exp.exponent';
 const incomingUrl =
   process.env.RCV_E2E_INCOMING_URL ??
@@ -36,6 +37,19 @@ function waitFor(pattern, description, timeout = 30_000) {
   throw new Error(`Timed out waiting for ${description}.`);
 }
 
+function scrollUntil(pattern, description, attempts = 6) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const xml = dump();
+    if (pattern.test(xml)) return xml;
+    run('shell', 'input', 'swipe', '540', '2200', '540', '350', '400');
+  }
+  throw new Error(`Could not locate ${description} after scrolling.`);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function center(bounds) {
   const match = bounds.match(/\[(\d+),(\d+)\]\[(\d+),(\d+)\]/);
   if (!match) throw new Error(`Invalid Android bounds: ${bounds}`);
@@ -64,6 +78,16 @@ const startArguments = [
 run(...startArguments);
 
 let xml = waitFor(/text="Shortcode: [^"]+"/, 'the incoming ballot link');
+
+if (groupOptionLabel) {
+  const optionPattern = new RegExp(
+    `content-desc="${escapeRegExp(groupOptionLabel)}"[^>]*bounds="([^"]+)"`,
+  );
+  xml = scrollUntil(optionPattern, `group option ${groupOptionLabel}`);
+  tapMatching(xml, optionPattern, `group option ${groupOptionLabel}`);
+}
+
+xml = scrollUntil(/content-desc="Move [^"]+ down"/, 'an accessible move-down control');
 tapMatching(
   xml,
   /content-desc="Move [^"]+ down"[^>]*bounds="([^"]+)"/,
@@ -72,23 +96,13 @@ tapMatching(
 waitFor(/content-desc="Move [^"]+ up"/, 'the updated candidate ranking');
 
 if (voterCode) {
-  for (let attempt = 0; attempt < 6; attempt += 1) {
-    xml = dump();
-    if (/content-desc="Voter code"/.test(xml)) break;
-    run('shell', 'input', 'swipe', '540', '2200', '540', '350', '400');
-  }
-  xml = dump();
+  xml = scrollUntil(/content-desc="Voter code"/, 'the voter-code field');
   tapMatching(xml, /content-desc="Voter code"[^>]*bounds="([^"]+)"/, 'the voter-code field');
   run('shell', 'input', 'text', voterCode);
   run('shell', 'input', 'keyevent', '4');
 }
 
-for (let attempt = 0; attempt < 6; attempt += 1) {
-  xml = dump();
-  if (/content-desc="Submit vote"/.test(xml)) break;
-  run('shell', 'input', 'swipe', '540', '2200', '540', '350', '400');
-}
-xml = dump();
+xml = scrollUntil(/content-desc="Submit vote"/, 'the submit button');
 tapMatching(xml, /content-desc="Submit vote"[^>]*bounds="([^"]+)"/, 'the submit button');
 
 waitFor(/text="Vote recorded"/, 'the accepted vote state');

--- a/apps/mobile/src/api/v2-api.test.ts
+++ b/apps/mobile/src/api/v2-api.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { V2ApiClient, V2ApiError } from './v2-api';
 
 const request = {
+  groupAnswers: { '12': '42', '13': false, '14': 'Blue' },
   key: 'pizza',
   requestId: '12345678-1234-4234-8234-123456789012',
   ranking: [3, 1, 2],
@@ -73,6 +74,26 @@ describe('V2ApiClient.submitVote', () => {
       code: 'invalid_voter_code',
       retryable: false,
       status: 403,
+    });
+  });
+
+  it('preserves invalid grouping-answer errors', async () => {
+    const client = new V2ApiClient({
+      baseUrl: 'https://example.test/api',
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            data: null,
+            error: { code: 'invalid_group_answers', message: 'Answers are invalid.' },
+          }),
+          { status: 422 },
+        ),
+    });
+
+    await expect(client.submitVote(request)).rejects.toMatchObject({
+      code: 'invalid_group_answers',
+      retryable: false,
+      status: 422,
     });
   });
 

--- a/apps/mobile/src/api/v2-api.ts
+++ b/apps/mobile/src/api/v2-api.ts
@@ -1,4 +1,5 @@
 export type SubmitVoteRequest = {
+  groupAnswers?: Record<string, string | boolean>;
   key: string;
   requestId: string;
   ranking: number[];
@@ -33,6 +34,7 @@ export type V2ApiErrorCode =
   | 'secure_code_required'
   | 'invalid_voter_code'
   | 'group_answers_required'
+  | 'invalid_group_answers'
   | 'fingerprint_required'
   | 'duplicate_device'
   | 'invalid_ranking'
@@ -77,6 +79,7 @@ function isKnownErrorCode(value: unknown): value is V2ApiErrorCode {
       'secure_code_required',
       'invalid_voter_code',
       'group_answers_required',
+      'invalid_group_answers',
       'fingerprint_required',
       'duplicate_device',
       'invalid_ranking',

--- a/apps/mobile/src/app/ballot/[key]/index.tsx
+++ b/apps/mobile/src/app/ballot/[key]/index.tsx
@@ -2,7 +2,9 @@ import { createLegacyApiClient } from '@/api/client';
 import { LegacyApiError, type BallotDetail, type Candidate } from '@/api/legacy-api';
 import { CandidateRanking } from '@/components/candidate-ranking';
 import { ElectionResults } from '@/components/election-results';
+import { GroupQuestions } from '@/components/group-questions';
 import { VoteSubmission } from '@/components/vote-submission';
+import type { GroupAnswers } from '@/features/group-answers';
 import { createRanking } from '@/features/ranking';
 import { useLocalSearchParams } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
@@ -25,6 +27,7 @@ export default function BallotScreen() {
   const [attempt, setAttempt] = useState(0);
   const [state, setState] = useState<LoadState>({ status: 'loading', key });
   const [ranking, setRanking] = useState<Candidate[]>([]);
+  const [groupAnswers, setGroupAnswers] = useState<GroupAnswers>({});
   const [voteAccepted, setVoteAccepted] = useState(false);
 
   useEffect(() => {
@@ -33,6 +36,7 @@ export default function BallotScreen() {
     client.getBallot(key, controller.signal).then(
       (detail) => {
         setRanking(createRanking(detail.candidates, detail.ballot.orderedEntries));
+        setGroupAnswers({});
         setVoteAccepted(false);
         setState({ status: 'loaded', key, detail });
       },
@@ -86,7 +90,7 @@ export default function BallotScreen() {
     );
   }
 
-  const { ballot, candidates } = state.detail;
+  const { ballot, candidates, groupFields } = state.detail;
 
   return (
     <ScrollView contentContainerStyle={styles.scrollContent} style={styles.screen}>
@@ -112,6 +116,10 @@ export default function BallotScreen() {
           ) : null}
         </View>
 
+        {!voteAccepted && ballot.allowGrouping ? (
+          <GroupQuestions answers={groupAnswers} fields={groupFields} onChange={setGroupAnswers} />
+        ) : null}
+
         {!voteAccepted ? (
           <>
             <Text style={styles.sectionTitle}>Your ranking</Text>
@@ -128,7 +136,13 @@ export default function BallotScreen() {
           </>
         ) : null}
 
-        <VoteSubmission ballot={ballot} onAccepted={() => setVoteAccepted(true)} ranking={ranking} />
+        <VoteSubmission
+          ballot={ballot}
+          groupAnswers={groupAnswers}
+          groupFields={groupFields}
+          onAccepted={() => setVoteAccepted(true)}
+          ranking={ranking}
+        />
         {voteAccepted ? <ElectionResults ballotKey={ballot.key} /> : null}
       </View>
     </ScrollView>

--- a/apps/mobile/src/components/group-questions.test.tsx
+++ b/apps/mobile/src/components/group-questions.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import type { GroupField } from '@/api/legacy-api';
+
+import { GroupQuestions } from './group-questions';
+
+const fields: GroupField[] = [
+  {
+    id: 1,
+    title: 'Region',
+    questionText: 'Where do you live?',
+    type: 'select',
+    required: true,
+    sortOrder: 0,
+    options: [{ id: 11, label: 'North', sortOrder: 0 }],
+  },
+  {
+    id: 2,
+    title: 'Member',
+    questionText: 'Are you a member?',
+    type: 'checkbox',
+    required: true,
+    sortOrder: 1,
+    options: [],
+  },
+  {
+    id: 3,
+    title: 'Team',
+    questionText: 'Which team?',
+    type: 'text',
+    required: false,
+    sortOrder: 2,
+    options: [],
+  },
+];
+
+describe('GroupQuestions', () => {
+  it('renders accessible controls for every supported question type', () => {
+    const html = renderToStaticMarkup(
+      <GroupQuestions
+        answers={{ '1': '11', '2': false, '3': 'Blue' }}
+        fields={fields}
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('Voter questions');
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toMatch(/aria-checked="true"[^>]*role="radio"/);
+    expect(html).toMatch(/aria-checked="false"[^>]*role="checkbox"/);
+    expect(html).toContain('aria-label="Which team?"');
+    expect(html).toContain('value="Blue"');
+  });
+});

--- a/apps/mobile/src/components/group-questions.tsx
+++ b/apps/mobile/src/components/group-questions.tsx
@@ -1,0 +1,155 @@
+import type { GroupField } from '@/api/legacy-api';
+import type { GroupAnswers, GroupAnswerValue } from '@/features/group-answers';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+
+type GroupQuestionsProps = {
+  answers: GroupAnswers;
+  disabled?: boolean;
+  fields: readonly GroupField[];
+  onChange: (answers: GroupAnswers) => void;
+};
+
+export function GroupQuestions({ answers, disabled = false, fields, onChange }: GroupQuestionsProps) {
+  const updateAnswer = (fieldId: number, value: GroupAnswerValue) => {
+    onChange({ ...answers, [String(fieldId)]: value });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Voter questions</Text>
+      <Text style={styles.helpText}>Answer these questions before submitting your ranking.</Text>
+
+      {fields.map((field) => {
+        const key = String(field.id);
+        const answer = answers[key];
+        const label = field.questionText || field.title;
+
+        if (field.type === 'checkbox') {
+          const checked = answer === true;
+          return (
+            <View key={field.id} style={styles.fieldCard}>
+              <Pressable
+                aria-checked={checked}
+                aria-disabled={disabled}
+                accessibilityLabel={label}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked, disabled }}
+                disabled={disabled}
+                onPress={() => updateAnswer(field.id, !checked)}
+                style={({ pressed }) => [styles.checkboxRow, pressed && styles.pressed]}>
+                <Text style={styles.checkboxMark}>{checked ? '☑' : '☐'}</Text>
+                <Text style={styles.checkboxLabel}>{label}</Text>
+              </Pressable>
+            </View>
+          );
+        }
+
+        return (
+          <View key={field.id} style={styles.fieldCard}>
+            <Text style={styles.label}>
+              {label}
+              {field.required ? ' *' : ''}
+            </Text>
+
+            {field.type === 'text' ? (
+              <TextInput
+                accessibilityLabel={label}
+                editable={!disabled}
+                maxLength={1000}
+                onChangeText={(value) => updateAnswer(field.id, value)}
+                placeholder="Enter your answer"
+                style={styles.textInput}
+                value={typeof answer === 'string' ? answer : ''}
+              />
+            ) : (
+              <View accessibilityLabel={label} accessibilityRole="radiogroup">
+                {!field.required ? (
+                  <RadioOption
+                    checked={!answer}
+                    disabled={disabled}
+                    label="No answer"
+                    onPress={() => updateAnswer(field.id, '')}
+                  />
+                ) : null}
+                {field.options.map((option) => (
+                  <RadioOption
+                    checked={answer === String(option.id)}
+                    disabled={disabled}
+                    key={option.id}
+                    label={option.label}
+                    onPress={() => updateAnswer(field.id, String(option.id))}
+                  />
+                ))}
+              </View>
+            )}
+          </View>
+        );
+      })}
+
+      {fields.some((field) => field.required && field.type !== 'checkbox') ? (
+        <Text style={styles.requiredNote}>* Required</Text>
+      ) : null}
+    </View>
+  );
+}
+
+type RadioOptionProps = {
+  checked: boolean;
+  disabled: boolean;
+  label: string;
+  onPress: () => void;
+};
+
+function RadioOption({ checked, disabled, label, onPress }: RadioOptionProps) {
+  return (
+    <Pressable
+      aria-checked={checked}
+      aria-disabled={disabled}
+      accessibilityLabel={label}
+      accessibilityRole="radio"
+      accessibilityState={{ checked, disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [styles.optionRow, checked && styles.optionSelected, pressed && styles.pressed]}>
+      <Text style={styles.radioMark}>{checked ? '●' : '○'}</Text>
+      <Text style={styles.optionLabel}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { marginTop: 26 },
+  title: { color: '#1f3143', fontSize: 22, fontWeight: '800' },
+  helpText: { color: '#52697f', fontSize: 14, lineHeight: 20, marginTop: 6 },
+  fieldCard: { backgroundColor: '#ffffff', borderRadius: 12, marginTop: 12, padding: 14 },
+  label: { color: '#263b33', fontSize: 15, fontWeight: '700', marginBottom: 10 },
+  textInput: {
+    borderColor: '#8aa097',
+    borderRadius: 9,
+    borderWidth: 1,
+    color: '#172b23',
+    fontSize: 16,
+    minHeight: 46,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  checkboxRow: { alignItems: 'center', flexDirection: 'row', minHeight: 44 },
+  checkboxMark: { color: '#146c43', fontSize: 25, marginRight: 10 },
+  checkboxLabel: { color: '#263b33', flex: 1, fontSize: 15, fontWeight: '700' },
+  optionRow: {
+    alignItems: 'center',
+    borderColor: '#d2ddd8',
+    borderRadius: 9,
+    borderWidth: 1,
+    flexDirection: 'row',
+    marginTop: 8,
+    minHeight: 44,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+  },
+  optionSelected: { backgroundColor: '#e8f2ed', borderColor: '#146c43' },
+  radioMark: { color: '#146c43', fontSize: 20, marginRight: 10 },
+  optionLabel: { color: '#263b33', flex: 1, fontSize: 15 },
+  requiredNote: { color: '#52697f', fontSize: 12, marginTop: 10 },
+  pressed: { opacity: 0.72 },
+});

--- a/apps/mobile/src/components/vote-submission.tsx
+++ b/apps/mobile/src/components/vote-submission.tsx
@@ -1,5 +1,5 @@
 import { createV2ApiClient } from '@/api/client';
-import type { Ballot, Candidate } from '@/api/legacy-api';
+import type { Ballot, Candidate, GroupField } from '@/api/legacy-api';
 import { V2ApiError } from '@/api/v2-api';
 import {
   blockerMessage,
@@ -10,6 +10,12 @@ import {
   type PendingVoteRequest,
 } from '@/features/vote-submission';
 import { loadInstallationId } from '@/utils/installation-id';
+import {
+  groupAnswersAreValid,
+  groupAnswersKey,
+  normalizeGroupAnswers,
+  type GroupAnswers,
+} from '@/features/group-answers';
 import * as Crypto from 'expo-crypto';
 import { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
@@ -22,11 +28,19 @@ type SubmissionState =
 
 type VoteSubmissionProps = {
   ballot: Ballot;
+  groupAnswers?: GroupAnswers;
+  groupFields?: readonly GroupField[];
   onAccepted: () => void;
   ranking: readonly Candidate[];
 };
 
-export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionProps) {
+export function VoteSubmission({
+  ballot,
+  groupAnswers = {},
+  groupFields = [],
+  onAccepted,
+  ranking,
+}: VoteSubmissionProps) {
   const client = useMemo(() => createV2ApiClient(), []);
   const [now, setNow] = useState(() => Date.now());
   const [request, setRequest] = useState<PendingVoteRequest | null>(null);
@@ -34,9 +48,14 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
   const rankingKey = ranking.map((candidate) => candidate.id).join(',');
   const normalizedVoterCode = normalizeVoterCode(voterCode);
   const ballotRankingKey = `${ballot.key}|${rankingKey}`;
-  const submissionKey = ballot.isSecure
+  const secureSubmissionKey = ballot.isSecure
     ? `${ballotRankingKey}|${normalizedVoterCode}`
     : ballotRankingKey;
+  const normalizedGroupAnswers = normalizeGroupAnswers(groupFields, groupAnswers);
+  const groupingValid = groupAnswersAreValid(groupFields, groupAnswers);
+  const submissionKey = ballot.allowGrouping
+    ? `${secureSubmissionKey}|${groupAnswersKey(groupFields, groupAnswers)}`
+    : secureSubmissionKey;
   const [state, setState] = useState<SubmissionState>({ status: 'idle', submissionKey });
   const currentState: SubmissionState =
     state.submissionKey === submissionKey ? state : { status: 'idle', submissionKey };
@@ -47,7 +66,7 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
     return () => clearInterval(timer);
   }, [ballot.voteCutoff]);
 
-  const blocker = getVoteBlocker(ballot, ranking.length, now, voterCode);
+  const blocker = getVoteBlocker(ballot, ranking.length, now, voterCode, groupingValid);
   const cutoffMessage = formatCutoffCountdown(ballot.voteCutoff, now);
 
   const submit = async () => {
@@ -65,6 +84,7 @@ export function VoteSubmission({ ballot, onAccepted, ranking }: VoteSubmissionPr
         requestId: activeRequestId,
         ranking: ranking.map((candidate) => candidate.id),
         fingerprint,
+        groupAnswers: ballot.allowGrouping ? normalizedGroupAnswers : undefined,
         voterCode: ballot.isSecure ? normalizedVoterCode : undefined,
       });
       setState({

--- a/apps/mobile/src/features/group-answers.test.ts
+++ b/apps/mobile/src/features/group-answers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GroupField } from '@/api/legacy-api';
+
+import {
+  groupAnswersAreValid,
+  groupAnswersKey,
+  normalizeGroupAnswers,
+  validateGroupAnswers,
+} from './group-answers';
+
+const fields: GroupField[] = [
+  {
+    id: 1,
+    title: 'Region',
+    questionText: 'Where do you live?',
+    type: 'select',
+    required: true,
+    sortOrder: 0,
+    options: [
+      { id: 11, label: 'North', sortOrder: 0 },
+      { id: 12, label: 'South', sortOrder: 1 },
+    ],
+  },
+  {
+    id: 2,
+    title: 'Member',
+    questionText: 'Are you a member?',
+    type: 'checkbox',
+    required: true,
+    sortOrder: 1,
+    options: [],
+  },
+  {
+    id: 3,
+    title: 'Team',
+    questionText: 'Which team?',
+    type: 'text',
+    required: false,
+    sortOrder: 2,
+    options: [],
+  },
+];
+
+describe('group answers', () => {
+  it('normalizes answers in configured field order', () => {
+    expect(normalizeGroupAnswers(fields, { '3': '  Blue  ', '1': '11' })).toEqual({
+      '1': '11',
+      '2': false,
+      '3': 'Blue',
+    });
+  });
+
+  it('accepts configured options, false checkboxes, and optional blank text', () => {
+    const answers = { '1': '12', '2': false, '3': '' };
+
+    expect(validateGroupAnswers(fields, answers)).toEqual({});
+    expect(groupAnswersAreValid(fields, answers)).toBe(true);
+  });
+
+  it('rejects missing required answers, unknown options, and oversized text', () => {
+    expect(validateGroupAnswers(fields, { '1': '99', '3': 'x'.repeat(1001) })).toEqual({
+      '1': 'Choose one of the available options.',
+      '3': 'Keep this answer under 1,000 characters.',
+    });
+    expect(validateGroupAnswers(fields, {})).toMatchObject({
+      '1': 'This question is required.',
+    });
+  });
+
+  it('builds a stable idempotency key independent of input insertion order', () => {
+    expect(groupAnswersKey(fields, { '3': 'Blue', '1': '11' })).toBe(
+      groupAnswersKey(fields, { '1': '11', '3': 'Blue' }),
+    );
+  });
+});

--- a/apps/mobile/src/features/group-answers.ts
+++ b/apps/mobile/src/features/group-answers.ts
@@ -1,0 +1,59 @@
+import type { GroupField } from '@/api/legacy-api';
+
+export type GroupAnswerValue = string | boolean;
+export type GroupAnswers = Record<string, GroupAnswerValue>;
+
+export function normalizeGroupAnswers(
+  fields: readonly GroupField[],
+  answers: GroupAnswers,
+): GroupAnswers {
+  return Object.fromEntries(
+    fields.map((field) => {
+      const answer = answers[String(field.id)];
+      if (field.type === 'checkbox') return [String(field.id), answer === true];
+      return [String(field.id), typeof answer === 'string' ? answer.trim() : ''];
+    }),
+  );
+}
+
+export function validateGroupAnswers(
+  fields: readonly GroupField[],
+  answers: GroupAnswers,
+): Record<string, string> {
+  const normalized = normalizeGroupAnswers(fields, answers);
+  const errors: Record<string, string> = {};
+
+  for (const field of fields) {
+    const key = String(field.id);
+    const answer = normalized[key];
+    if (field.type === 'checkbox') continue;
+
+    if (field.required && answer === '') {
+      errors[key] = 'This question is required.';
+      continue;
+    }
+
+    if (
+      field.type === 'select' &&
+      answer !== '' &&
+      !field.options.some((option) => String(option.id) === answer)
+    ) {
+      errors[key] = 'Choose one of the available options.';
+    } else if (field.type === 'text' && typeof answer === 'string' && answer.length > 1000) {
+      errors[key] = 'Keep this answer under 1,000 characters.';
+    }
+  }
+
+  return errors;
+}
+
+export function groupAnswersAreValid(
+  fields: readonly GroupField[],
+  answers: GroupAnswers,
+): boolean {
+  return Object.keys(validateGroupAnswers(fields, answers)).length === 0;
+}
+
+export function groupAnswersKey(fields: readonly GroupField[], answers: GroupAnswers): string {
+  return JSON.stringify(normalizeGroupAnswers(fields, answers));
+}

--- a/apps/mobile/src/features/vote-submission.test.ts
+++ b/apps/mobile/src/features/vote-submission.test.ts
@@ -60,6 +60,7 @@ describe('vote submission states', () => {
     expect(getVoteBlocker({ ...ballot, isSecure: true }, 2, now, 'short')).toBe('secure_code_required');
     expect(getVoteBlocker({ ...ballot, isSecure: true }, 2, now, 'ABC001')).toBeNull();
     expect(getVoteBlocker({ ...ballot, allowGrouping: true }, 2, now)).toBe('group_answers_required');
+    expect(getVoteBlocker({ ...ballot, allowGrouping: true }, 2, now, '', true)).toBeNull();
     expect(getVoteBlocker(ballot, 0, now)).toBe('empty_ranking');
     expect(getVoteBlocker(ballot, 2, now)).toBeNull();
   });

--- a/apps/mobile/src/features/vote-submission.ts
+++ b/apps/mobile/src/features/vote-submission.ts
@@ -40,12 +40,13 @@ export function getVoteBlocker(
   rankingCount: number,
   now = Date.now(),
   voterCode = '',
+  groupAnswersValid = false,
 ): VoteBlocker | null {
   const cutoff = parseUtcTimestamp(ballot.voteCutoff);
   if (cutoff !== null && now >= cutoff) return 'closed';
   if (ballot.register === 1) return 'voter_name_required';
   if (ballot.isSecure && normalizeVoterCode(voterCode).length !== 6) return 'secure_code_required';
-  if (ballot.allowGrouping) return 'group_answers_required';
+  if (ballot.allowGrouping && !groupAnswersValid) return 'group_answers_required';
   if (rankingCount === 0) return 'empty_ranking';
   return null;
 }
@@ -61,7 +62,7 @@ export function blockerMessage(blocker: VoteBlocker): string {
     case 'secure_code_required':
       return 'Enter the six-character voter code to submit this ballot.';
     case 'group_answers_required':
-      return 'This ballot requires voter questions that are not available in the anonymous flow.';
+      return 'Answer all required voter questions before submitting.';
   }
 }
 

--- a/docs/expo-migration-rfc.md
+++ b/docs/expo-migration-rfc.md
@@ -1,8 +1,8 @@
 # Expo Migration RFC
 
-- Status: Accepted; Phases 0 and 1 implemented
+- Status: Accepted; Phases 0 and 1 implemented; Phase 2 in progress
 - Date: 2026-08-08
-- Last updated: 2026-09-04
+- Last updated: 2026-09-05
 - Proposer: Emmanuel Jones
 - Decision horizon: architecture and first product milestone
 - Maintainer guidance received: 2026-08-30
@@ -73,7 +73,8 @@ or setup workflow.
 | Secure voter codes | `code.html`, validation and management endpoints | Milestone 2 |
 | Registration and login | `register.html`, `auth.js` | Milestone 3 |
 | Profile and ballot management | `profile.html`, `manage.html` | Milestone 3 |
-| Group questions | create, vote, results, CSV export | Milestone 4 |
+| Group-question collection while voting | vote flow | Milestone 2 |
+| Grouping configuration, analysis, and export | create, results, CSV export | Milestone 4 |
 | RCVis integration | browser iframe plus cURL PHP endpoints | Milestone 4 |
 | Custom HTML/iframe content | browser-specific rendering and editing | Permanently web-only |
 | Admin and wrapping-paper calculator | separate browser-only surfaces | Permanently web-only |
@@ -366,6 +367,13 @@ the server verifies that it is assigned to the ballot, serializes redemption,
 stores the code in the legacy vote-name field, and preserves idempotent replay
 for an identical request. Invalid and previously used codes intentionally
 share one nonspecific client error.
+
+Grouping-question collection is likewise independent of guest-ballot
+ownership. The native client renders the existing select, checkbox, and text
+field definitions returned with a ballot. The v2 vote endpoint validates field
+and option ownership, required answers, types, and text length, then stores the
+normalized answers in the existing `votes.group_answers` column. Grouping
+configuration, analysis, and export remain web-only initially.
 
 ### Phase 3 — authentication and management
 

--- a/src/api/v2/README.md
+++ b/src/api/v2/README.md
@@ -29,7 +29,12 @@ The vote endpoint accepts anonymous and secure-code ballots:
   "requestId": "client_generated_16_to_64_chars",
   "ranking": [42, 17, 23],
   "fingerprint": "optional-installation-identifier",
-  "voterCode": "optional-six-character-code"
+  "voterCode": "optional-six-character-code",
+  "groupAnswers": {
+    "7": "19",
+    "8": false,
+    "9": "optional text answer"
+  }
 }
 ```
 
@@ -42,8 +47,17 @@ Secure codes are normalized to lowercase, with `0` treated as `o` and `1`
 treated as `i`, matching the legacy voting flow. Each assigned code can record
 one vote. Missing codes return `secure_code_required`; unassigned or previously
 used codes return the deliberately nonspecific `invalid_voter_code` response.
-Ballots that require a voter name or grouping answers still return typed
-unsupported states for the client.
+
+For ballots with grouping enabled, `groupAnswers` is required and keyed by
+group-field ID. Select answers contain an option ID, checkbox answers are JSON
+booleans, and text answers are strings of at most 1,000 characters. The server
+verifies that every field and selected option belongs to the ballot, supplies
+`false`/empty defaults for optional answers, and returns
+`invalid_group_answers` with field-specific errors when validation fails.
+Grouping answers are included in the idempotency hash.
+
+Ballots that require a voter name still return a typed unsupported state for
+the anonymous client.
 
 ## `GET /api/v2/results.php?key=ballot-shortcode`
 

--- a/src/api/v2/votes.php
+++ b/src/api/v2/votes.php
@@ -68,6 +68,108 @@ function normalizeVoterCode($value): ?string
     return strlen($code) === 6 ? $code : null;
 }
 
+function canonicalizeGroupAnswers($value): ?array
+{
+    if (!is_array($value)) {
+        return null;
+    }
+
+    $answers = [];
+    foreach ($value as $fieldId => $answer) {
+        $id = is_int($fieldId) ? $fieldId : (is_string($fieldId) && ctype_digit($fieldId) ? (int) $fieldId : 0);
+        if ($id <= 0 || array_key_exists($id, $answers)) {
+            return null;
+        }
+
+        if (is_bool($answer)) {
+            $answers[$id] = $answer;
+        } elseif (is_string($answer)) {
+            $answers[$id] = trim($answer);
+        } elseif (is_int($answer) && $answer > 0) {
+            $answers[$id] = (string) $answer;
+        } else {
+            return null;
+        }
+    }
+
+    ksort($answers, SORT_NUMERIC);
+    return $answers;
+}
+
+function validateGroupAnswers(PDO $dbh, int $ballotId, array $answers): array
+{
+    $fieldStatement = $dbh->prepare(
+        'SELECT id, type, required FROM voter_group_fields WHERE ballot_id = :ballotId ORDER BY sort_order ASC, id ASC'
+    );
+    $fieldStatement->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
+    $fieldStatement->execute();
+    $groupFields = $fieldStatement->fetchAll(PDO::FETCH_ASSOC);
+
+    $optionStatement = $dbh->prepare(
+        'SELECT o.id, o.field_id FROM voter_group_options o '
+        . 'JOIN voter_group_fields f ON f.id = o.field_id '
+        . 'WHERE f.ballot_id = :ballotId'
+    );
+    $optionStatement->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
+    $optionStatement->execute();
+    $optionIds = [];
+    foreach ($optionStatement->fetchAll(PDO::FETCH_ASSOC) as $option) {
+        $optionIds[(int) $option['field_id']][(int) $option['id']] = true;
+    }
+
+    $knownFields = [];
+    $normalized = [];
+    $errors = [];
+    foreach ($groupFields as $field) {
+        $fieldId = (int) $field['id'];
+        $knownFields[$fieldId] = true;
+        $type = (string) ($field['type'] ?: 'select');
+        $required = (int) $field['required'] === 1;
+        $hasAnswer = array_key_exists($fieldId, $answers);
+        $answer = $hasAnswer ? $answers[$fieldId] : null;
+        $errorKey = 'groupAnswers.' . $fieldId;
+
+        if ($type === 'checkbox') {
+            if ($hasAnswer && !is_bool($answer)) {
+                $errors[$errorKey] = 'Choose yes or no.';
+            } else {
+                $normalized[$fieldId] = $hasAnswer ? $answer : false;
+            }
+            continue;
+        }
+
+        if ($type === 'text') {
+            if ($hasAnswer && !is_string($answer)) {
+                $errors[$errorKey] = 'Enter a text answer.';
+            } elseif ($required && (!$hasAnswer || $answer === '')) {
+                $errors[$errorKey] = 'This question is required.';
+            } elseif ($hasAnswer && strlen($answer) > 1000) {
+                $errors[$errorKey] = 'Keep this answer under 1,000 characters.';
+            } else {
+                $normalized[$fieldId] = $hasAnswer ? $answer : '';
+            }
+            continue;
+        }
+
+        $optionId = is_string($answer) && ctype_digit($answer) ? (int) $answer : 0;
+        if ($required && (!$hasAnswer || $optionId === 0)) {
+            $errors[$errorKey] = 'This question is required.';
+        } elseif ($hasAnswer && ($optionId === 0 || empty($optionIds[$fieldId][$optionId]))) {
+            $errors[$errorKey] = 'Choose one of the available options.';
+        } else {
+            $normalized[$fieldId] = $optionId === 0 ? '' : (string) $optionId;
+        }
+    }
+
+    foreach ($answers as $fieldId => $_answer) {
+        if (empty($knownFields[$fieldId])) {
+            $errors['groupAnswers.' . $fieldId] = 'This question does not belong to the ballot.';
+        }
+    }
+
+    return ['answers' => $normalized, 'errors' => $errors];
+}
+
 function findIdempotentVote(PDO $dbh, int $ballotId, string $requestId): ?array
 {
     $statement = $dbh->prepare(
@@ -122,14 +224,29 @@ if (!$ballot) {
 
 $ballotId = (int) $ballot['id'];
 $isSecure = (int) $ballot['isSecure'] === 1;
+$allowsGrouping = (int) $ballot['allowGrouping'] === 1;
 $voterCode = $isSecure ? normalizeVoterCode($input['voterCode'] ?? null) : null;
 if ($isSecure && $voterCode === null) {
     fail(422, 'secure_code_required', 'Enter the six-character voter code.');
 }
 
+$groupAnswers = null;
+if ($allowsGrouping) {
+    if (!array_key_exists('groupAnswers', $input)) {
+        fail(422, 'group_answers_required', 'Answer the ballot questions before submitting.');
+    }
+    $groupAnswers = canonicalizeGroupAnswers($input['groupAnswers']);
+    if ($groupAnswers === null) {
+        fail(422, 'invalid_group_answers', 'One or more ballot answers are invalid.');
+    }
+}
+
 $requestPayload = ['ranking' => $ranking];
 if ($isSecure) {
     $requestPayload['voterCode'] = $voterCode;
+}
+if ($allowsGrouping) {
+    $requestPayload['groupAnswers'] = $groupAnswers;
 }
 $requestHash = hash('sha256', json_encode($requestPayload, JSON_UNESCAPED_SLASHES));
 $existingVote = findIdempotentVote($dbh, $ballotId, $requestId);
@@ -152,8 +269,13 @@ if ((int) $ballot['register'] === 1) {
     fail(409, 'voter_name_required', 'This ballot requires a voter name, which is not supported in the anonymous flow.');
 }
 
-if ((int) $ballot['allowGrouping'] === 1) {
-    fail(409, 'group_answers_required', 'This ballot requires voter questions.');
+$groupAnswersJson = null;
+if ($allowsGrouping) {
+    $groupValidation = validateGroupAnswers($dbh, $ballotId, $groupAnswers);
+    if ($groupValidation['errors'] !== []) {
+        fail(422, 'invalid_group_answers', 'One or more ballot answers are invalid.', $groupValidation['errors']);
+    }
+    $groupAnswersJson = json_encode($groupValidation['answers'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 }
 
 $fingerprint = isset($input['fingerprint']) && is_string($input['fingerprint'])
@@ -253,7 +375,7 @@ try {
     $insert = $dbh->prepare(
         'INSERT INTO votes '
         . '(ballotId, date_created, vote, voteIds, ipAddress, name, fingerprint, group_answers, requestKey, requestHash) '
-        . 'VALUES (:ballotId, UTC_TIMESTAMP(), :vote, :voteIds, :ipAddress, :voterName, :fingerprint, NULL, :requestKey, :requestHash)'
+        . 'VALUES (:ballotId, UTC_TIMESTAMP(), :vote, :voteIds, :ipAddress, :voterName, :fingerprint, :groupAnswers, :requestKey, :requestHash)'
     );
     $insert->bindValue(':ballotId', $ballotId, PDO::PARAM_INT);
     $insert->bindValue(':vote', $voteJson, PDO::PARAM_STR);
@@ -261,6 +383,11 @@ try {
     $insert->bindValue(':ipAddress', $_SERVER['REMOTE_ADDR'] ?? '', PDO::PARAM_STR);
     $insert->bindValue(':voterName', $voterCode ?? '', PDO::PARAM_STR);
     $insert->bindValue(':fingerprint', $fingerprint, PDO::PARAM_STR);
+    $insert->bindValue(
+        ':groupAnswers',
+        $groupAnswersJson,
+        $groupAnswersJson === null ? PDO::PARAM_NULL : PDO::PARAM_STR
+    );
     $insert->bindValue(':requestKey', $requestId, PDO::PARAM_STR);
     $insert->bindValue(':requestHash', $requestHash, PDO::PARAM_STR);
     $insert->execute();

--- a/test/contract/live-php-api.test.js
+++ b/test/contract/live-php-api.test.js
@@ -39,7 +39,7 @@ async function requestApi(method, endpoint, { query, body } = {}) {
   };
 }
 
-async function createBallot({ isSecure = false, codeCount = 0 } = {}) {
+async function createBallot({ isSecure = false, codeCount = 0, allowGrouping = false } = {}) {
   const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const key = `contract-${uniqueId}`;
   const createdBy = `contract-test-${uniqueId}`;
@@ -54,7 +54,8 @@ async function createBallot({ isSecure = false, codeCount = 0 } = {}) {
       sqlVoteCutoff: '2099-12-31 23:59:59',
       sqlResultsRelease: '2099-12-31 23:59:59',
       isSecure,
-      codeCount
+      codeCount,
+      allowGrouping
     }
   });
 
@@ -154,12 +155,16 @@ describe('live PHP API contracts', () => {
     const candidates = await requestApi('GET', 'get-candidates.php', {
       query: { key: ballot.key }
     });
+    const codes = await requestApi('POST', 'get-ballot-codes.php', {
+      body: { ballotId: ballot.ballotId, createdBy: ballot.createdBy }
+    });
+    const voterCode = codes.json.codes[0].code;
     const ranking = candidates.json.candidates.map((candidate) => Number(candidate.entry_id));
     const body = {
       key: ballot.key,
       requestId: `secure_contract_${Date.now()}`,
       ranking,
-      voterCode: 'E2EABC'
+      voterCode: voterCode.toUpperCase()
     };
 
     const first = await requestApi('POST', 'v2/votes.php', { body });
@@ -185,6 +190,93 @@ describe('live PHP API contracts', () => {
     });
   });
 
+  it('validates and records grouping answers through the v2 vote contract', async () => {
+    const ballot = await createBallot({ allowGrouping: true });
+    const savedFields = await requestApi('POST', 'save-group-fields.php', {
+      body: {
+        ballotId: ballot.ballotId,
+        createdBy: ballot.createdBy,
+        fields: [
+          {
+            title: 'Region',
+            question_text: 'Where do you live?',
+            type: 'select',
+            required: true,
+            options: ['North', 'South']
+          },
+          {
+            title: 'Member',
+            question_text: 'Are you a member?',
+            type: 'checkbox',
+            required: true,
+            options: []
+          },
+          {
+            title: 'Team',
+            question_text: 'Which team?',
+            type: 'text',
+            required: false,
+            options: []
+          }
+        ]
+      }
+    });
+
+    expect(savedFields.json).toEqual({ data: { success: true } });
+
+    const candidates = await requestApi('GET', 'get-candidates.php', {
+      query: { key: ballot.key }
+    });
+    const [region, member, team] = candidates.json.groupFields;
+    const north = region.options.find((option) => option.label === 'North');
+    const ranking = candidates.json.candidates.map((candidate) => Number(candidate.entry_id));
+    const groupAnswers = {
+      [region.id]: String(north.id),
+      [member.id]: false,
+      [team.id]: '  Blue  '
+    };
+
+    const invalid = await requestApi('POST', 'v2/votes.php', {
+      body: {
+        key: ballot.key,
+        requestId: `group_invalid_${Date.now()}`,
+        ranking,
+        groupAnswers: { ...groupAnswers, [region.id]: '999999999' }
+      }
+    });
+    expect(invalid.status).toBe(422);
+    expect(invalid.json).toMatchObject({
+      data: null,
+      error: {
+        code: 'invalid_group_answers',
+        fields: { [`groupAnswers.${region.id}`]: expect.any(String) }
+      }
+    });
+
+    const accepted = await requestApi('POST', 'v2/votes.php', {
+      body: {
+        key: ballot.key,
+        requestId: `group_contract_${Date.now()}`,
+        ranking,
+        groupAnswers
+      }
+    });
+    expect(accepted.status).toBe(201);
+    expect(accepted.json).toMatchObject({
+      data: { status: 'accepted', replayed: false },
+      error: null
+    });
+
+    const votes = await requestApi('GET', 'get-votes.php', {
+      query: { key: ballot.key }
+    });
+    expect(JSON.parse(votes.json.votes[0].group_answers)).toEqual({
+      [region.id]: String(north.id),
+      [member.id]: false,
+      [team.id]: 'Blue'
+    });
+  });
+
   it('creates a ballot, returns candidates, records a vote, and returns results', async () => {
     const ballot = await createBallot();
 
@@ -196,8 +288,7 @@ describe('live PHP API contracts', () => {
       ballot: expect.objectContaining({
         id: ballot.ballotId,
         key: ballot.key,
-        name: ballot.ballotName,
-        positions: 1
+        name: ballot.ballotName
       }),
       candidates: expect.arrayContaining([
         expect.objectContaining({ candidate: 'Alpha' }),
@@ -206,6 +297,7 @@ describe('live PHP API contracts', () => {
       ]),
       groupFields: []
     });
+    expect(Number(candidates.json.ballot.positions)).toBe(1);
 
     const candidateIds = candidates.json.candidates.map((candidate) => candidate.entry_id);
 

--- a/test/php/V2VoteTest.php
+++ b/test/php/V2VoteTest.php
@@ -149,6 +149,80 @@ class V2VoteTest extends ApiTestCase
         $this->assertSame(1, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
     }
 
+    public function testRecordsValidatedGroupingAnswers(): void
+    {
+        $key = 'grouped-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'allowGrouping' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice', 'Bob']);
+        $selectId = $this->seedGroupField($ballotId, ['title' => 'Region', 'type' => 'select']);
+        $northId = $this->seedGroupOption($selectId, 'North');
+        $checkboxId = $this->seedGroupField($ballotId, [
+            'title' => 'Member',
+            'type' => 'checkbox',
+            'sort_order' => 1,
+        ]);
+        $textId = $this->seedGroupField($ballotId, [
+            'title' => 'Team',
+            'type' => 'text',
+            'sort_order' => 2,
+        ]);
+
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'groupAnswers' => [
+                (string) $selectId => (string) $northId,
+                (string) $checkboxId => false,
+                (string) $textId => '  Blue team  ',
+            ],
+        ]));
+
+        $this->assertSame('accepted', $result['body']['data']['status']);
+        $stored = json_decode($this->db->query('SELECT group_answers FROM votes')->fetchColumn(), true);
+        $this->assertSame((string) $northId, $stored[$selectId]);
+        $this->assertFalse($stored[$checkboxId]);
+        $this->assertSame('Blue team', $stored[$textId]);
+    }
+
+    public function testRejectsInvalidGroupingAnswers(): void
+    {
+        $key = 'grouped-invalid-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'allowGrouping' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice']);
+        $selectId = $this->seedGroupField($ballotId, ['title' => 'Region', 'type' => 'select']);
+        $otherBallotId = $this->seedBallot();
+        $otherFieldId = $this->seedGroupField($otherBallotId, ['title' => 'Other']);
+        $foreignOptionId = $this->seedGroupOption($otherFieldId, 'Elsewhere');
+
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'groupAnswers' => [
+                (string) $selectId => (string) $foreignOptionId,
+                (string) $otherFieldId => 'unexpected',
+            ],
+        ]));
+
+        $this->assertSame('invalid_group_answers', $result['body']['error']['code']);
+        $this->assertArrayHasKey('groupAnswers.' . $selectId, $result['body']['error']['fields']);
+        $this->assertArrayHasKey('groupAnswers.' . $otherFieldId, $result['body']['error']['fields']);
+        $this->assertSame(0, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
+    }
+
+    public function testRejectsAReusedRequestIdWithDifferentGroupingAnswers(): void
+    {
+        $key = 'grouped-conflict-' . uniqid();
+        $ballotId = $this->seedBallot(['key' => $key, 'allowGrouping' => 1]);
+        $entryIds = $this->seedEntries($ballotId, ['Alice']);
+        $fieldId = $this->seedGroupField($ballotId, ['title' => 'Team', 'type' => 'text']);
+
+        $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'groupAnswers' => [(string) $fieldId => 'Blue'],
+        ]));
+        $result = $this->callApi('v2/votes.php', $this->validRequest($key, $entryIds, [
+            'groupAnswers' => [(string) $fieldId => 'Green'],
+        ]));
+
+        $this->assertSame('idempotency_conflict', $result['body']['error']['code']);
+        $this->assertSame(1, (int) $this->db->query('SELECT COUNT(*) FROM votes')->fetchColumn());
+    }
+
     public function testRejectsInvalidRequestFields(): void
     {
         $result = $this->callApi('v2/votes.php', [


### PR DESCRIPTION
## Summary

- render accessible select, checkbox, and text voter questions in the Expo ballot flow
- validate and normalize grouping answers in the mobile client and v2 vote endpoint
- verify field/option ownership server-side, persist normalized answers, and include them in idempotency
- extend unit, live MySQL, and Android device coverage

## Verification

- npm test (191 Vitest; 225 PHPUnit / 539 assertions)
- npm run test:api-contract (6 live PHP/MySQL scenarios)
- mobile npm test (41 tests)
- mobile npm run typecheck
- mobile npm run lint
- mobile npx expo export --platform web
- npm run build
- Android device E2E: incoming grouped ballot link -> answer North -> reorder -> submit -> local results; live API confirmed the selected option in votes.group_answers

## Stack

This PR is based on #75 (native secure-code voting). It should be reviewed after #73, #74, and #75.