### PR TITLE
Add native canonical ballot sharing

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -7,8 +7,9 @@ idempotent v2 vote endpoint. Released votes are loaded through the public v2
 results contract and calculated locally by the pure `packages/rcv-core`
 TypeScript module. Secure ballots can be submitted with an assigned voter
 code. Ballots with voter grouping enabled render and validate their select,
-checkbox, and text questions before submission. The app does not authenticate
-users yet.
+checkbox, and text questions before submission. Ballot and results screens can
+open the system share sheet with the canonical RankedChoices.com ballot link.
+The app does not authenticate users yet.
 
 ## Get started
 
@@ -89,6 +90,15 @@ ADB="$ANDROID_HOME/platform-tools/adb" \
 npm run test:android:e2e
 ```
 
+To verify the native system share sheet without submitting a vote:
+
+```bash
+RCV_E2E_BALLOT_KEY=pizza \
+RCV_E2E_SHARE_ONLY=1 \
+ADB="$ANDROID_HOME/platform-tools/adb" \
+npm run test:android:e2e
+```
+
 Expo Go is the default target. A development build can exercise the custom
 scheme with:
 
@@ -124,6 +134,7 @@ connectivity will be designed alongside the later web deployment decision.
   invalid/reused-code, duplicate-device, cutoff, and accepted states
 - accessible select, checkbox, and text grouping questions with client and
   server validation
+- canonical ballot-link sharing through the native system share sheet
 - local winner and round-by-round result rendering after an accepted vote
 - loading, closed, not-found, malformed-response, and network-error handling
 

--- a/apps/mobile/scripts/android-phase1-e2e.mjs
+++ b/apps/mobile/scripts/android-phase1-e2e.mjs
@@ -4,6 +4,7 @@ const adb = process.env.ADB ?? 'adb';
 const ballotKey = process.env.RCV_E2E_BALLOT_KEY ?? 'pizza';
 const voterCode = process.env.RCV_E2E_VOTER_CODE?.trim();
 const groupOptionLabel = process.env.RCV_E2E_GROUP_OPTION_LABEL?.trim();
+const shareOnly = process.env.RCV_E2E_SHARE_ONLY === '1';
 const appPackage = process.env.RCV_E2E_APP_PACKAGE ?? 'host.exp.exponent';
 const incomingUrl =
   process.env.RCV_E2E_INCOMING_URL ??
@@ -78,6 +79,19 @@ const startArguments = [
 run(...startArguments);
 
 let xml = waitFor(/text="Shortcode: [^"]+"/, 'the incoming ballot link');
+
+if (shareOnly) {
+  tapMatching(
+    xml,
+    /content-desc="Share ballot"[^>]*bounds="([^"]+)"/,
+    'the native share action',
+  );
+  const canonicalUrl = `https://rankedchoices.com/ballot/${encodeURIComponent(ballotKey)}`;
+  waitFor(new RegExp(escapeRegExp(canonicalUrl)), 'the canonical link in the system share sheet');
+  run('shell', 'input', 'keyevent', '4');
+  console.log(`Android share E2E passed for ${canonicalUrl}`);
+  process.exit(0);
+}
 
 if (groupOptionLabel) {
   const optionPattern = new RegExp(

--- a/apps/mobile/src/app/ballot/[key]/index.tsx
+++ b/apps/mobile/src/app/ballot/[key]/index.tsx
@@ -1,5 +1,6 @@
 import { createLegacyApiClient } from '@/api/client';
 import { LegacyApiError, type BallotDetail, type Candidate } from '@/api/legacy-api';
+import { BallotShareButton } from '@/components/ballot-share-button';
 import { CandidateRanking } from '@/components/candidate-ranking';
 import { ElectionResults } from '@/components/election-results';
 import { GroupQuestions } from '@/components/group-questions';
@@ -98,6 +99,7 @@ export default function BallotScreen() {
         <Text style={styles.eyebrow}>RANK YOUR CHOICES</Text>
         <Text style={styles.title}>{ballot.name}</Text>
         <Text style={styles.shortcode}>Shortcode: {ballot.key}</Text>
+        <BallotShareButton ballotKey={ballot.key} ballotName={ballot.name} />
 
         <View style={styles.metaRow}>
           <View style={styles.metaCard}>
@@ -143,7 +145,16 @@ export default function BallotScreen() {
           onAccepted={() => setVoteAccepted(true)}
           ranking={ranking}
         />
-        {voteAccepted ? <ElectionResults ballotKey={ballot.key} /> : null}
+        {voteAccepted ? (
+          <>
+            <ElectionResults ballotKey={ballot.key} />
+            <BallotShareButton
+              ballotKey={ballot.key}
+              ballotName={ballot.name}
+              label="Share this ballot"
+            />
+          </>
+        ) : null}
       </View>
     </ScrollView>
   );

--- a/apps/mobile/src/components/ballot-share-button.test.tsx
+++ b/apps/mobile/src/components/ballot-share-button.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { BallotShareButton } from './ballot-share-button';
+
+describe('BallotShareButton', () => {
+  it('renders an accessible native-share action', () => {
+    const html = renderToStaticMarkup(
+      <BallotShareButton ballotKey="pizza" ballotName="Pizza night" />,
+    );
+
+    expect(html).toContain('aria-label="Share ballot"');
+    expect(html).toContain('role="button"');
+    expect(html).toContain('Share ballot</div>');
+  });
+});

--- a/apps/mobile/src/components/ballot-share-button.tsx
+++ b/apps/mobile/src/components/ballot-share-button.tsx
@@ -1,0 +1,65 @@
+import { ballotShareContent, ballotShareOptions } from '@/features/ballot-sharing';
+import { useState } from 'react';
+import { Pressable, Share, StyleSheet, Text, View } from 'react-native';
+
+type BallotShareButtonProps = {
+  ballotKey: string;
+  ballotName: string;
+  label?: string;
+};
+
+export function BallotShareButton({
+  ballotKey,
+  ballotName,
+  label = 'Share ballot',
+}: BallotShareButtonProps) {
+  const [sharing, setSharing] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  const share = async () => {
+    setFailed(false);
+    setSharing(true);
+    try {
+      await Share.share(ballotShareContent(ballotName, ballotKey), ballotShareOptions(ballotName));
+    } catch {
+      setFailed(true);
+    } finally {
+      setSharing(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        accessibilityHint="Opens the system share sheet with the ballot link"
+        accessibilityLabel={label}
+        accessibilityRole="button"
+        accessibilityState={{ busy: sharing, disabled: sharing }}
+        disabled={sharing}
+        onPress={share}
+        style={({ pressed }) => [styles.button, pressed && styles.pressed]}>
+        <Text style={styles.buttonText}>{sharing ? 'Opening…' : label}</Text>
+      </Pressable>
+      {failed ? (
+        <Text accessibilityLiveRegion="assertive" style={styles.errorText}>
+          Could not open sharing. Try again.
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'flex-start', marginTop: 14 },
+  button: {
+    backgroundColor: '#12355b',
+    borderRadius: 10,
+    minHeight: 44,
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  buttonText: { color: '#ffffff', fontSize: 14, fontWeight: '800' },
+  errorText: { color: '#81261f', fontSize: 13, marginTop: 7 },
+  pressed: { opacity: 0.76 },
+});

--- a/apps/mobile/src/features/ballot-sharing.test.ts
+++ b/apps/mobile/src/features/ballot-sharing.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ballotShareContent,
+  ballotShareOptions,
+  canonicalBallotUrl,
+} from './ballot-sharing';
+
+describe('canonicalBallotUrl', () => {
+  it('trims and safely encodes the shortcode in the canonical ballot route', () => {
+    expect(canonicalBallotUrl(' pizza night ')).toBe(
+      'https://rankedchoices.com/ballot/pizza%20night',
+    );
+    expect(canonicalBallotUrl('team/choice')).toBe(
+      'https://rankedchoices.com/ballot/team%2Fchoice',
+    );
+  });
+});
+
+describe('ballot share payload', () => {
+  it('includes the canonical URL in cross-platform message and URL fields', () => {
+    expect(ballotShareContent(' Pizza night ', 'pizza')).toEqual({
+      message: 'Vote in “Pizza night” on Ranked Choices: https://rankedchoices.com/ballot/pizza',
+      title: 'Share Pizza night',
+      url: 'https://rankedchoices.com/ballot/pizza',
+    });
+    expect(ballotShareOptions(' Pizza night ')).toEqual({
+      dialogTitle: 'Share Pizza night',
+      subject: 'Vote in Pizza night',
+    });
+  });
+});

--- a/apps/mobile/src/features/ballot-sharing.ts
+++ b/apps/mobile/src/features/ballot-sharing.ts
@@ -1,0 +1,30 @@
+export const RANKED_CHOICES_ORIGIN = 'https://rankedchoices.com';
+
+export type BallotShareContent = {
+  message: string;
+  title: string;
+  url: string;
+};
+
+export function canonicalBallotUrl(key: string): string {
+  return `${RANKED_CHOICES_ORIGIN}/ballot/${encodeURIComponent(key.trim())}`;
+}
+
+export function ballotShareContent(ballotName: string, key: string): BallotShareContent {
+  const name = ballotName.trim() || 'this ballot';
+  const url = canonicalBallotUrl(key);
+
+  return {
+    message: `Vote in “${name}” on Ranked Choices: ${url}`,
+    title: `Share ${name}`,
+    url,
+  };
+}
+
+export function ballotShareOptions(ballotName: string) {
+  const name = ballotName.trim() || 'Ranked Choices ballot';
+  return {
+    dialogTitle: `Share ${name}`,
+    subject: `Vote in ${name}`,
+  };
+}

--- a/docs/expo-migration-rfc.md
+++ b/docs/expo-migration-rfc.md
@@ -375,6 +375,12 @@ and option ownership, required answers, types, and text length, then stores the
 normalized answers in the existing `votes.group_answers` column. Grouping
 configuration, analysis, and export remain web-only initially.
 
+Canonical sharing also does not depend on ballot ownership. The ballot and
+results experience generates `https://rankedchoices.com/ballot/<key>` and
+passes it to the native system share sheet. The URL is included in both the
+cross-platform message and the iOS URL field so shared links are canonical on
+both platforms.
+
 ### Phase 3 — authentication and management
 
 - Implement server-side password hashing, migrate legacy hashes on successful


### PR DESCRIPTION
## Summary

- generate canonical https://rankedchoices.com/ballot/<key> links in the Expo client
- expose share actions before voting and alongside results
- use the built-in React Native system share sheet without adding a dependency
- include the URL in the Android-compatible message and the iOS URL field
- add helper/component coverage and an Android share-only device scenario

## Verification

- npm test (191 Vitest; 225 PHPUnit / 539 assertions)
- npm run build
- mobile npm test (44 tests)
- mobile npm run typecheck
- mobile npm run lint
- mobile npx expo export --platform web
- Android device E2E opened the system chooser and asserted it contained https://rankedchoices.com/ballot/pizza

## Stack

This PR is based on #77 (native grouping-question voting). It should be reviewed after #73, #74, #75, and #77.