### PR TITLE
Add secure guest ballot creation API

### DIFF
--- a/src/api/SETUP.md
+++ b/src/api/SETUP.md
@@ -42,6 +42,15 @@ For example, Phase 1 vote idempotency requires:
 mysql -u rcv_user -p rcv_db < src/api/migrations/2026-08-16-vote-idempotency.sql
 ```
 
+Native guest ballot creation additionally requires:
+
+```bash
+mysql -u rcv_user -p rcv_db < src/api/migrations/2026-09-06-ballot-management-tokens.sql
+```
+
+Apply this migration before deploying the guest-creation API and its legacy
+mutation guards.
+
 ## Manual Setup (Alternative)
 
 If you prefer to set up step-by-step or need to customize the process:

--- a/src/api/add-entries.php
+++ b/src/api/add-entries.php
@@ -23,6 +23,14 @@ if (!empty($_POST['entries'])) {
 if (empty($ballotId))
 	$errors['ballotId'] = 'Ballot ID is required.';
 
+if (!empty($ballotId)) {
+	$managedBallot = $dbh->prepare('SELECT 1 FROM ballot_management_tokens WHERE ballot_id = :ballotId LIMIT 1');
+	$managedBallot->execute([':ballotId' => $ballotId]);
+	if ($managedBallot->fetchColumn()) {
+		$errors['authorization'] = 'This ballot requires a management token.';
+	}
+}
+
 function sanitizeName($name) {
 	$name = html_entity_decode($name, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 	$name = preg_replace(

--- a/src/api/create-graph.php
+++ b/src/api/create-graph.php
@@ -12,7 +12,11 @@ if ($key) {
       voteCutoff = UTC_TIMESTAMP(),
       graphUpdated = UTC_TIMESTAMP()
 		WHERE
-			`key` = :key;";
+			`key` = :key
+		AND NOT EXISTS (
+			SELECT 1 FROM ballot_management_tokens
+			WHERE ballot_management_tokens.ballot_id = ballots.id
+		);";
 
 	$sth = $dbh->prepare($query);
 	$sth->execute([':key' => $key]);

--- a/src/api/delete-vote.php
+++ b/src/api/delete-vote.php
@@ -48,6 +48,10 @@ if(!empty($voteId)) {
         `graphUpdated` = NULL
       WHERE
         `key` = :ballotShortcode
+		AND NOT EXISTS (
+			SELECT 1 FROM ballot_management_tokens
+			WHERE ballot_management_tokens.ballot_id = ballots.id
+		)
     ;";
     $sth2 = $dbh->prepare($query2);
     $sth2->bindValue(':ballotShortcode', $ballotShortcode, PDO::PARAM_STR);

--- a/src/api/duplicate-ballot.php
+++ b/src/api/duplicate-ballot.php
@@ -15,6 +15,14 @@ if (empty($ballotId))
 if (empty($duplicateBallotId))
 	$errors['duplicateBallotId'] = 'Duplicate Ballot ID is required.';
 
+if (!empty($ballotId)) {
+	$managedBallot = $dbh->prepare('SELECT 1 FROM ballot_management_tokens WHERE ballot_id = :ballotId LIMIT 1');
+	$managedBallot->execute([':ballotId' => $ballotId]);
+	if ($managedBallot->fetchColumn()) {
+		$errors['authorization'] = 'This ballot requires a management token.';
+	}
+}
+
 if (!empty($errors)) {
 	$data['errors']  = $errors;
 	$data['post'] = $_POST;

--- a/src/api/get-candidates.php
+++ b/src/api/get-candidates.php
@@ -25,6 +25,12 @@ if(!empty($key)) {
 	if (!$ballot) {
 		echo "Shortcode not found.";
 	} else {
+		// Token-managed native ballots use a non-public owner marker so legacy
+		// owner endpoints cannot bypass the management credential.
+		if (strpos($ballot['createdBy'], 'native:') === 0) {
+			$ballot['createdBy'] = 'guest';
+		}
+
 		// Check voting cutoff for non-edit requests
 		if (!$edit) {
 			$cutoffSth = $dbh->prepare("SELECT 1 FROM ballots WHERE id = :id AND (voteCutoff IS NULL OR UTC_TIMESTAMP() < voteCutoff)");

--- a/src/api/get-votes.php
+++ b/src/api/get-votes.php
@@ -24,6 +24,10 @@ if(!empty($key)) {
 	if (!$ballot) {
 		echo "Shortcode not found.";
 	} else {
+		if (strpos($ballot['createdBy'], 'native:') === 0) {
+			$ballot['createdBy'] = 'guest';
+		}
+
 		$ballotId = $ballot['id'];
 
 		// Fetch votes (vote data only, no ballot metadata on each row)

--- a/src/api/migrations/2026-09-06-ballot-management-tokens.sql
+++ b/src/api/migrations/2026-09-06-ballot-management-tokens.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `ballot_management_tokens` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `ballot_id` int NOT NULL,
+  `token_digest` char(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  `claimed_at` datetime DEFAULT NULL,
+  `revoked_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `token_digest` (`token_digest`),
+  KEY `ballot_id` (`ballot_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+

--- a/src/api/setup-database-prod.sql
+++ b/src/api/setup-database-prod.sql
@@ -113,6 +113,23 @@ CREATE TABLE `ballot_codes` (
 
 
 
+# Dump of table ballot_management_tokens
+# ------------------------------------------------------------
+
+CREATE TABLE `ballot_management_tokens` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `ballot_id` int NOT NULL,
+  `token_digest` char(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  `created_at` datetime NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  `claimed_at` datetime DEFAULT NULL,
+  `revoked_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `token_digest` (`token_digest`),
+  KEY `ballot_id` (`ballot_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
 # Dump of table users
 # ------------------------------------------------------------
 

--- a/src/api/v2/README.md
+++ b/src/api/v2/README.md
@@ -19,6 +19,34 @@ Version 2 endpoints use one JSON envelope for success and failure:
 }
 ```
 
+## `POST /api/v2/ballots.php`
+
+Creates a deliberately basic guest ballot:
+
+```json
+{
+  "name": "Lunch choice",
+  "candidates": ["Tacos", "Curry", "Pizza"]
+}
+```
+
+The server validates and trims the name and 2–100 unique candidate names,
+generates an eight-character shortcode, and applies the ordinary single-seat
+defaults. Client-supplied owner IDs, shortcodes, or advanced settings are not
+accepted as authority and do not change those defaults.
+
+The successful response includes a 256-bit URL-safe `managementToken`. It is
+returned only in this response and must be stored in native SecureStore. The
+database stores only its SHA-256 digest in `ballot_management_tokens`. The raw
+token must not be logged, placed in URLs, included in telemetry, or shared with
+the public ballot link. A later authenticated claim contract will require both
+account authentication and this credential, then revoke or rotate it.
+
+Token-managed ballots also receive an unpredictable internal owner marker that
+public ballot responses mask as `guest`. Legacy mutation paths that do not
+verify an owner are blocked for these ballots, closing the otherwise-available
+legacy bypass around the new credential.
+
 ## `POST /api/v2/votes.php`
 
 The vote endpoint accepts anonymous and secure-code ballots:

--- a/src/api/v2/ballots.php
+++ b/src/api/v2/ballots.php
@@ -1,0 +1,179 @@
+<?php
+
+require_once __DIR__ . '/../config.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+
+function respond(int $status, ?array $data, ?array $error): void
+{
+    http_response_code($status);
+    echo json_encode(['data' => $data, 'error' => $error]);
+    exit;
+}
+
+function fail(int $status, string $code, string $message, ?array $fields = null): void
+{
+    $error = ['code' => $code, 'message' => $message];
+    if ($fields !== null) {
+        $error['fields'] = $fields;
+    }
+    respond($status, null, $error);
+}
+
+function validText($value, int $maxCharacters): ?string
+{
+    if (!is_string($value)) {
+        return null;
+    }
+
+    $text = trim($value);
+    if (
+        $text === ''
+        || preg_match('//u', $text) !== 1
+        || preg_match('/[\x00-\x1F\x7F]/u', $text) === 1
+        || preg_match('/[\x{10000}-\x{10FFFF}]/u', $text) === 1
+        || preg_match_all('/./us', $text) > $maxCharacters
+    ) {
+        return null;
+    }
+
+    return $text;
+}
+
+function normalizedCandidateKey(string $name): string
+{
+    return function_exists('mb_strtolower') ? mb_strtolower($name, 'UTF-8') : strtolower($name);
+}
+
+function randomUrlSafeString(int $bytes): string
+{
+    return rtrim(strtr(base64_encode(random_bytes($bytes)), '+/', '-_'), '=');
+}
+
+$rawRequest = file_get_contents('php://input');
+$request = json_decode($rawRequest, true);
+if (!is_array($request) || json_last_error() !== JSON_ERROR_NONE) {
+    fail(400, 'invalid_json', 'Send a JSON object.');
+}
+
+$fields = [];
+$name = validText($request['name'] ?? null, 64);
+if ($name === null) {
+    $fields['name'] = 'Enter a ballot name of 64 characters or fewer.';
+}
+
+$candidateValues = $request['candidates'] ?? null;
+$candidates = [];
+if (!is_array($candidateValues) || count($candidateValues) < 2 || count($candidateValues) > 100) {
+    $fields['candidates'] = 'Enter between 2 and 100 candidates.';
+} else {
+    $seenCandidates = [];
+    foreach ($candidateValues as $index => $candidateValue) {
+        $candidate = validText($candidateValue, 256);
+        if ($candidate === null) {
+            $fields['candidates.' . $index] = 'Enter a candidate name of 256 characters or fewer.';
+            continue;
+        }
+
+        $candidateKey = normalizedCandidateKey($candidate);
+        if (isset($seenCandidates[$candidateKey])) {
+            $fields['candidates.' . $index] = 'Candidate names must be unique.';
+            continue;
+        }
+
+        $seenCandidates[$candidateKey] = true;
+        $candidates[] = $candidate;
+    }
+}
+
+if ($fields !== []) {
+    fail(422, 'validation_failed', 'Check the ballot details and try again.', $fields);
+}
+
+$ballotId = null;
+try {
+    $managementToken = randomUrlSafeString(32);
+    $tokenDigest = hash('sha256', $managementToken);
+    $ownerMarker = 'native:' . bin2hex(random_bytes(16));
+
+    for ($attempt = 0; $attempt < 5; $attempt++) {
+        $key = bin2hex(random_bytes(4));
+        $keyStatement = $dbh->prepare('SELECT COUNT(*) FROM ballots WHERE `key` = :key');
+        $keyStatement->execute([':key' => $key]);
+        if ((int) $keyStatement->fetchColumn() === 0) {
+            break;
+        }
+    }
+
+    if (!isset($key) || $attempt === 5) {
+        throw new RuntimeException('Could not allocate a ballot shortcode.');
+    }
+
+    $dbh->beginTransaction();
+
+    $ballotStatement = $dbh->prepare(
+        'INSERT INTO ballots '
+        . '(`name`, `timeCreated`, `key`, `positions`, `createdBy`, `requireSignIn`, '
+        . '`tieBreak`, `register`, `allowCustom`, `hideNames`, `hideDetails`, `showGraph`, '
+        . '`maxVotes`, `oneDeviceOneVote`, `isSecure`, `orderedEntries`, `allowGrouping`, `bordaActive`) '
+        . 'VALUES '
+        . '(:name, UTC_TIMESTAMP(), :key, 1, :ownerMarker, 0, \'weighted\', 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0)'
+    );
+    $ballotStatement->execute([':name' => $name, ':key' => $key, ':ownerMarker' => $ownerMarker]);
+    $ballotId = (int) $dbh->lastInsertId();
+
+    $entryStatement = $dbh->prepare(
+        'INSERT INTO entries (`ballotId`, `name`, `image`, `hyperlink`, `color`) '
+        . 'VALUES (:ballotId, :name, \'\', \'\', NULL)'
+    );
+    $candidateData = [];
+    foreach ($candidates as $candidate) {
+        $entryStatement->execute([':ballotId' => $ballotId, ':name' => $candidate]);
+        $candidateData[] = ['id' => (int) $dbh->lastInsertId(), 'name' => $candidate];
+    }
+
+    $tokenStatement = $dbh->prepare(
+        'INSERT INTO ballot_management_tokens (`ballot_id`, `token_digest`, `created_at`) '
+        . 'VALUES (:ballotId, :tokenDigest, UTC_TIMESTAMP())'
+    );
+    $tokenStatement->execute([':ballotId' => $ballotId, ':tokenDigest' => $tokenDigest]);
+
+    $dbh->commit();
+
+    respond(201, [
+        'status' => 'created',
+        'ballot' => [
+            'id' => $ballotId,
+            'key' => $key,
+            'name' => $name,
+            'positions' => 1,
+        ],
+        'candidates' => $candidateData,
+        'managementToken' => $managementToken,
+    ], null);
+} catch (Throwable $error) {
+    if ($dbh->inTransaction()) {
+        $dbh->rollBack();
+    }
+
+    // ballots and entries are MyISAM in production, so a transaction cannot
+    // roll them back. Compensate after any partial failure.
+    if ($ballotId !== null) {
+        foreach ([
+            'DELETE FROM ballot_management_tokens WHERE ballot_id = :ballotId',
+            'DELETE FROM entries WHERE ballotId = :ballotId',
+            'DELETE FROM ballots WHERE id = :ballotId',
+        ] as $cleanupQuery) {
+            try {
+                $cleanupStatement = $dbh->prepare($cleanupQuery);
+                $cleanupStatement->execute([':ballotId' => $ballotId]);
+            } catch (Throwable $cleanupError) {
+                // Keep attempting the remaining compensating deletes and
+                // return the same non-sensitive client error below.
+            }
+        }
+    }
+
+    fail(500, 'server_error', 'The ballot could not be created. Try again.');
+}

--- a/test/php/ApiTestCase.php
+++ b/test/php/ApiTestCase.php
@@ -23,7 +23,7 @@ abstract class ApiTestCase extends TestCase
         $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
         // Clean all tables for test isolation
-        foreach (['votes', 'entries', 'ballot_codes', 'random_codes', 'voter_group_options', 'voter_group_fields', 'ballots', 'users', 'contributions'] as $table) {
+        foreach (['votes', 'entries', 'ballot_codes', 'ballot_management_tokens', 'random_codes', 'voter_group_options', 'voter_group_fields', 'ballots', 'users', 'contributions'] as $table) {
             $this->db->exec("DELETE FROM $table");
         }
     }

--- a/test/php/SchemaDriftTest.php
+++ b/test/php/SchemaDriftTest.php
@@ -115,6 +115,7 @@ class SchemaDriftTest extends TestCase
         'entries',
         'random_codes',
         'ballot_codes',
+        'ballot_management_tokens',
         'users',
         'votes',
         'voter_group_fields',

--- a/test/php/V2BallotTest.php
+++ b/test/php/V2BallotTest.php
@@ -1,0 +1,137 @@
+<?php
+
+require_once __DIR__ . '/ApiTestCase.php';
+
+class V2BallotTest extends ApiTestCase
+{
+    public function testCreatesABasicGuestBallotAndReturnsManagementToken(): void
+    {
+        $result = $this->callApi('v2/ballots.php', [
+            'name' => '  Lunch choice  ',
+            'candidates' => ['  Tacos  ', 'Curry', 'Pizza'],
+            'createdBy' => 'attacker-supplied-owner',
+            'isSecure' => true,
+            'positions' => 12,
+        ]);
+
+        $this->assertSame('created', $result['body']['data']['status']);
+        $this->assertNull($result['body']['error']);
+        $this->assertSame('Lunch choice', $result['body']['data']['ballot']['name']);
+        $this->assertSame(1, $result['body']['data']['ballot']['positions']);
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{8}$/', $result['body']['data']['ballot']['key']);
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9_-]{43}$/', $result['body']['data']['managementToken']);
+
+        $ballot = $this->db->query('SELECT * FROM ballots')->fetch(PDO::FETCH_ASSOC);
+        $this->assertMatchesRegularExpression('/^native:[a-f0-9]{32}$/', $ballot['createdBy']);
+        $this->assertSame(1, (int) $ballot['positions']);
+        $this->assertSame('weighted', $ballot['tieBreak']);
+        $this->assertSame(1, (int) $ballot['maxVotes']);
+        foreach (['requireSignIn', 'register', 'allowCustom', 'hideNames', 'hideDetails', 'showGraph', 'oneDeviceOneVote', 'isSecure', 'orderedEntries', 'allowGrouping', 'bordaActive'] as $field) {
+            $this->assertSame(0, (int) $ballot[$field], $field . ' must keep the basic-ballot default');
+        }
+
+        $entryNames = $this->db->query('SELECT name FROM entries ORDER BY entry_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['Tacos', 'Curry', 'Pizza'], $entryNames);
+
+        $tokenRow = $this->db->query('SELECT * FROM ballot_management_tokens')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame((int) $ballot['id'], (int) $tokenRow['ballot_id']);
+        $this->assertSame(64, strlen($tokenRow['token_digest']));
+        $this->assertSame(
+            hash('sha256', $result['body']['data']['managementToken']),
+            $tokenRow['token_digest']
+        );
+        $this->assertNotSame($result['body']['data']['managementToken'], $tokenRow['token_digest']);
+
+        $publicBallot = $this->callApi('get-candidates.php', [], ['key' => $ballot['key']]);
+        $this->assertSame('guest', $publicBallot['body']['ballot']['createdBy']);
+        $this->assertStringNotContainsString($ballot['createdBy'], $publicBallot['raw']);
+    }
+
+    public function testReturnsUniqueTokensAndShortcodes(): void
+    {
+        $first = $this->callApi('v2/ballots.php', [
+            'name' => 'First',
+            'candidates' => ['A', 'B'],
+        ]);
+        $second = $this->callApi('v2/ballots.php', [
+            'name' => 'Second',
+            'candidates' => ['A', 'B'],
+        ]);
+
+        $this->assertNotSame($first['body']['data']['ballot']['key'], $second['body']['data']['ballot']['key']);
+        $this->assertNotSame($first['body']['data']['managementToken'], $second['body']['data']['managementToken']);
+        $this->assertSame(2, (int) $this->db->query('SELECT COUNT(*) FROM ballots')->fetchColumn());
+        $this->assertSame(2, (int) $this->db->query('SELECT COUNT(*) FROM ballot_management_tokens')->fetchColumn());
+    }
+
+    public function testRejectsInvalidBallotDetailsWithoutWritingData(): void
+    {
+        $result = $this->callApi('v2/ballots.php', [
+            'name' => ' ',
+            'candidates' => ['Same', ' same '],
+        ]);
+
+        $this->assertSame('validation_failed', $result['body']['error']['code']);
+        $this->assertArrayHasKey('name', $result['body']['error']['fields']);
+        $this->assertArrayHasKey('candidates.1', $result['body']['error']['fields']);
+        $this->assertSame(0, (int) $this->db->query('SELECT COUNT(*) FROM ballots')->fetchColumn());
+        $this->assertSame(0, (int) $this->db->query('SELECT COUNT(*) FROM entries')->fetchColumn());
+        $this->assertSame(0, (int) $this->db->query('SELECT COUNT(*) FROM ballot_management_tokens')->fetchColumn());
+    }
+
+    public function testRejectsCandidateCountsOutsideTheBasicFlowLimit(): void
+    {
+        $tooFew = $this->callApi('v2/ballots.php', [
+            'name' => 'Too few',
+            'candidates' => ['Only one'],
+        ]);
+        $tooMany = $this->callApi('v2/ballots.php', [
+            'name' => 'Too many',
+            'candidates' => array_fill(0, 101, 'Candidate'),
+        ]);
+
+        $this->assertSame('validation_failed', $tooFew['body']['error']['code']);
+        $this->assertArrayHasKey('candidates', $tooFew['body']['error']['fields']);
+        $this->assertSame('validation_failed', $tooMany['body']['error']['code']);
+        $this->assertArrayHasKey('candidates', $tooMany['body']['error']['fields']);
+    }
+
+    public function testRejectsTextTheLegacyDatabaseCannotStore(): void
+    {
+        $result = $this->callApi('v2/ballots.php', [
+            'name' => 'Emoji ballot 😀',
+            'candidates' => ['A', 'B'],
+        ]);
+
+        $this->assertSame('validation_failed', $result['body']['error']['code']);
+        $this->assertArrayHasKey('name', $result['body']['error']['fields']);
+    }
+
+    public function testLegacyEntryAndGraphMutationsCannotBypassTheManagementToken(): void
+    {
+        $created = $this->callApi('v2/ballots.php', [
+            'name' => 'Protected',
+            'candidates' => ['Original A', 'Original B'],
+        ]);
+        $ballotId = $created['body']['data']['ballot']['id'];
+        $key = $created['body']['data']['ballot']['key'];
+
+        $entries = $this->callApi('add-entries.php', [
+            'ballotId' => $ballotId,
+            'entries' => ['Injected A', 'Injected B'],
+            'images' => ['', ''],
+            'hyperlinks' => ['', ''],
+        ]);
+        $this->callApi('create-graph.php', [], ['key' => $key]);
+
+        $this->assertSame(
+            'This ballot requires a management token.',
+            $entries['body']['errors']['authorization']
+        );
+        $storedEntries = $this->db->query('SELECT name FROM entries ORDER BY entry_id')->fetchAll(PDO::FETCH_COLUMN);
+        $this->assertSame(['Original A', 'Original B'], $storedEntries);
+        $ballot = $this->db->query('SELECT showGraph, voteCutoff FROM ballots')->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame(0, (int) $ballot['showGraph']);
+        $this->assertNull($ballot['voteCutoff']);
+    }
+}

--- a/test/php/schema-sqlite.sql
+++ b/test/php/schema-sqlite.sql
@@ -63,6 +63,17 @@ CREATE TABLE ballot_codes (
 );
 CREATE INDEX random_code_idx ON ballot_codes (random_code_id);
 
+CREATE TABLE ballot_management_tokens (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ballot_id int NOT NULL,
+  token_digest char(64) NOT NULL,
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  claimed_at datetime DEFAULT NULL,
+  revoked_at datetime DEFAULT NULL,
+  UNIQUE (token_digest)
+);
+CREATE INDEX ballot_management_token_ballot_id ON ballot_management_tokens (ballot_id);
+
 CREATE TABLE users (
   id bigint NOT NULL,
   username varchar(64) NOT NULL,


### PR DESCRIPTION
## Summary
- add a typed `POST /api/v2/ballots.php` contract for name-and-candidates guest creation
- generate the shortcode, 256-bit management token, and internal owner marker on the server
- store only the management-token SHA-256 digest and return the raw credential once with `Cache-Control: no-store`
- force basic single-seat defaults and ignore caller-supplied identity or advanced settings
- mask the internal owner marker on public reads and close unauthenticated legacy entry/graph mutation bypasses
- add the production migration, schema-parity fixture, API documentation, and PHP contract tests

## Verification
- `npm test`: 191 Vitest tests; 231 PHPUnit tests / 587 assertions
- PHP syntax checks for every changed endpoint
- live MySQL: creation, digest match, public read, and blocked legacy mutation verified with a disposable ballot and cleanup
- `git diff --check`

## Deployment note
Apply `src/api/migrations/2026-09-06-ballot-management-tokens.sql` before deploying this endpoint and its legacy mutation guards.

## Stack
This PR stacks on #80, which records the corresponding maintainer guidance in the RFC.