### PR TITLE
Correct and verify database setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,21 +20,19 @@ This is a Ranked Choice Voting (RCV) calculator web application hosted at ranked
 # Install dependencies
 npm install
 
-# Start development server (frontend only, port 3000)
+# Start development server (frontend only, port 2460)
 npm run dev
 
 # Build for production
 npm run build
 
 # Preview production build
-npm preview
+npm run preview
 
 # Start PHP backend (required for API calls during development)
 # IMPORTANT: Always start this when testing locally — Vite proxies /api to localhost:2461
 cd src && php -S localhost:2461
 
-# Alternative: Use Docker Compose for full stack
-docker-compose up
 ```
 
 ## Architecture
@@ -68,36 +66,33 @@ PHP backend in `src/api/` directory. All API endpoints:
 - Use PDO for database access
 - No authentication framework - uses simple cookie-based sessions
 
-**Database connection**: Configure in `src/api/config.php` (copy from `config_sample.php`). For Docker, set SERVER to `'db:3306'`.
+**Database connection**: Configure in `src/api/config.php` (copy from `config_sample.php`).
 
 ### Database Schema
 
-MySQL database with 4 main tables:
+The MySQL database has four core application tables:
 - `ballots` - Ballot metadata (name, key/shortcode, positions, settings, timestamps)
 - `entries` - Candidates/choices for each ballot
 - `votes` - Individual votes (stores serialized ranking data)
 - `users` - User accounts (supports Google/Facebook OAuth and local accounts)
 
-Schema in `Schema.sql`. Important: Production database (`public_html/` folder) may have different schema than `Schema.sql` - see seed data scripts for current production structure.
+The complete fresh-install schema is `src/api/setup-database-prod.sql`. Upgrade
+an existing database by applying unapplied files in `src/api/migrations/` in
+filename order; do not re-run the full schema over existing data. See
+`src/api/SETUP.md` for commands, verification, and safe rollout guidance.
 
 ## Development Workflow
 
 ### Local Development Setup
 
 1. Create `src/api/config.php` from `src/api/config_sample.php`
-2. Set up MySQL database using `Schema.sql`
+2. Set up a fresh MySQL database using `src/api/setup-database-prod.sql`, or
+   upgrade an existing database with the ordered files in `src/api/migrations/`
 3. Run `npm install`
 4. Start two terminals:
-   - Terminal 1: `npm run dev` (frontend dev server on port 3000)
+   - Terminal 1: `npm run dev` (frontend dev server on port 2460)
    - Terminal 2: `cd src && php -S localhost:2461` (PHP backend)
 5. The Vite dev server proxies `/api` requests to `localhost:2461`
-
-### Docker Development
-
-Alternatively, use Docker Compose which sets up both frontend and MySQL:
-- Ensure `src/api/config.php` has SERVER set to `'db:3306'`
-- Run `docker-compose up`
-- Access at `localhost:1337`
 
 ### Deployment
 
@@ -105,7 +100,10 @@ Run `./deploy.sh` to build and deploy to production via rsync over SSH. Requires
 
 ### Production vs Development Code Split
 
-**Important context**: This repo was historically far removed from production. The `public_html/` folder contains what's currently in production and may have features/fixes not in `src/`. Recent work has modernized the build system to bridge this gap.
+**Important context**: This repo was historically far removed from production.
+Recent work modernized the build and maintains the production-aligned database
+shape in `src/api/setup-database-prod.sql`; migrations remain necessary for
+existing deployments.
 
 ## Key Files
 
@@ -115,7 +113,9 @@ Run `./deploy.sh` to build and deploy to production via rsync over SSH. Requires
 - `src/main-entry.js` - Vite entry point (imports app code and bundled dependencies)
 - `vite.config.js` - Build configuration with proxy setup
 - `src/api/config.php` - Database credentials (gitignored, copy from sample)
-- `Schema.sql` - Database schema
+- `src/api/setup-database-prod.sql` - Complete fresh-install database schema
+- `src/api/migrations/` - Ordered upgrades for existing databases
+- `src/api/SETUP.md` - Local setup and migration verification guide
 
 ## API Patterns
 

--- a/src/api/SETUP.md
+++ b/src/api/SETUP.md
@@ -51,6 +51,69 @@ mysql -u rcv_user -p rcv_db < src/api/migrations/2026-09-06-ballot-management-to
 Apply this migration before deploying the guest-creation API and its legacy
 mutation guards.
 
+#### Safe rollout checklist for the management-token migration
+
+This migration is an additive `CREATE TABLE`: it does not alter or copy any
+existing ballot, entry, vote, or user row. MySQL DDL commits independently,
+however, so treat the schema change and application deployment as two explicit
+steps rather than expecting a transaction to roll both back.
+
+1. **Take the normal verified database snapshot or backup.** Confirm that the
+   backup can be located and restored before changing production. This is a
+   standard deployment guard even though this migration does not mutate an
+   existing table.
+2. **Check for a conflicting table before applying the file:**
+
+   ```sql
+   SELECT TABLE_NAME
+   FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = 'rcv_db'
+     AND TABLE_NAME = 'ballot_management_tokens';
+   ```
+
+   No row is the expected starting state. If a row is returned, inspect the
+   table with `SHOW CREATE TABLE ballot_management_tokens;` and compare it with
+   the migration. `IF NOT EXISTS` makes an exact re-run harmless, but it does
+   not repair a pre-existing table with the wrong columns or indexes.
+3. **Apply the migration before the application code:**
+
+   ```bash
+   mysql -u rcv_user -p rcv_db < src/api/migrations/2026-09-06-ballot-management-tokens.sql
+   ```
+
+   Deploying in this order matters because the guest-creation endpoint and its
+   legacy mutation guards query the new table.
+4. **Verify the resulting shape before deploying PHP:**
+
+   ```sql
+   SHOW CREATE TABLE ballot_management_tokens;
+   SHOW INDEX FROM ballot_management_tokens;
+   SELECT COUNT(*) FROM ballot_management_tokens;
+   ```
+
+   Confirm that the table uses InnoDB; has `id`, `ballot_id`, `token_digest`,
+   `created_at`, `claimed_at`, and `revoked_at`; has a unique index on
+   `token_digest` and an index on `ballot_id`; and is empty before the feature
+   is used.
+5. **Run the API checks, then deploy a canary:**
+
+   ```bash
+   ./vendor/bin/phpunit test/php/V2BallotTest.php
+   ```
+
+   On a local or staging MySQL database, create one disposable basic ballot
+   through the native flow. Verify one token row exists for its ballot, that
+   `token_digest` is 64 lowercase hexadecimal characters, that public ballot
+   reads expose `createdBy` as `guest`, and that the guarded legacy mutations
+   reject the ballot. Do not print the raw management token in terminal or CI
+   logs. Remove the disposable ballot, entries, and token row afterward.
+6. **Monitor and roll back conservatively.** Watch guest-creation HTTP 5xx
+   responses and database errors. If the application must be rolled back,
+   revert the application code first. The unused table can safely remain. Drop
+   it only after confirming it contains no management credentials and no
+   deployed code references it; once real rows exist, preserve the table for a
+   forward fix instead of destroying access credentials.
+
 ## Manual Setup (Alternative)
 
 If you prefer to set up step-by-step or need to customize the process:
@@ -106,19 +169,20 @@ mysql -u rcv_user -p'rcv_password' rcv_db -e "SHOW TABLES;"
 You should see:
 
 ```
-+-----------------------+
-| Tables_in_rcv_db      |
-+-----------------------+
-| ballot_codes          |
-| ballots               |
-| contributions         |
-| entries               |
-| random_codes          |
-| users                 |
-| voter_group_fields    |
-| voter_group_options   |
-| votes                 |
-+-----------------------+
++--------------------------+
+| Tables_in_rcv_db         |
++--------------------------+
+| ballot_codes             |
+| ballot_management_tokens |
+| ballots                  |
+| contributions            |
+| entries                  |
+| random_codes             |
+| users                    |
+| voter_group_fields       |
+| voter_group_options      |
+| votes                    |
++--------------------------+
 ```
 
 ## Create Config File
@@ -217,6 +281,7 @@ systemctl status mysql
 The complete schema is maintained in `setup-database-prod.sql`, which is synchronized with production. Key tables:
 
 - **ballots** - Ballot metadata, configuration, and settings
+- **ballot_management_tokens** - One-way guest management-token digests and lifecycle timestamps
 - **entries** - Candidates/choices for each ballot
 - **votes** - Individual votes with rankings
 - **users** - User accounts (supports OAuth and local auth)

--- a/start-local.sh
+++ b/start-local.sh
@@ -49,7 +49,7 @@ echo "Starting PHP server on http://localhost:2461 ..."
 (cd src && php -S localhost:2461) &
 PHP_PID=$!
 
-echo "Starting Vite dev server on http://localhost:3000 ..."
+echo "Starting Vite dev server on http://localhost:2460 ..."
 npm run dev &
 VITE_PID=$!
 


### PR DESCRIPTION
## Summary
- add a production-safe rollout checklist for the ballot management-token migration
- document backup, conflict preflight, schema verification, deployment ordering, canary checks, monitoring, and conservative rollback
- add ballot_management_tokens to the expected fresh-install table list and schema reference
- replace the nonexistent Schema.sql and Docker Compose references with the maintained production schema and ordered migrations
- correct the preview command and Vite port in developer/startup guidance

## Verification
- reapplied the migration to local MySQL to verify idempotence
- confirmed InnoDB, the six expected columns, primary/unique/ballot indexes, and zero rows
- focused V2BallotTest: 6 tests / 48 assertions
- full suite: 191 Vitest tests; 231 PHPUnit tests / 587 assertions
- bash syntax check for start-local.sh
- stale setup-reference scan and git diff --check

## Context
Follow-up to merged PR #81. The full fresh-install schema already contained the table and the existing-database section already named the migration; this closes the missing verification and rollback guidance and removes stale alternate setup paths.