### PR TITLE
Prepare mobile app store launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,3 +305,6 @@ This project is open source and free to use. See [LICENSE](LICENSE) file for det
 If you find this app useful, consider [supporting the project](https://paypal.me/rankedchoices).
 
 For questions or feedback, email [davidmoritz@gmail.com](mailto:davidmoritz@gmail.com).
+
+Review the [privacy policy](https://rankedchoices.com/privacy-policy.html) for how the website and
+mobile apps handle ballot, vote, account, device, and diagnostic data.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -59,6 +59,37 @@ committing the eventual store identity:
 APP_VARIANT=development npx expo run:android
 ```
 
+For iOS, install full Xcode, an iOS simulator runtime, CocoaPods, and CMake.
+The ordinary development-build command generates the ignored native workspace,
+installs pods, builds, and starts the simulator:
+
+```bash
+APP_VARIANT=development npx expo run:ios
+```
+
+To build through Xcode or Xcode MCP, generate and open the workspace explicitly:
+
+```bash
+APP_VARIANT=development npx expo prebuild --platform ios --no-install
+cd ios
+APP_VARIANT=development pod install
+open RankedChoicesDev.xcworkspace
+```
+
+Run the PHP API in a separate terminal. If Expo's development launcher cannot
+reach `127.0.0.1` because Metro selected IPv6 localhost, start Metro with IPv4
+resolution while keeping it off the LAN:
+
+```bash
+NODE_OPTIONS=--dns-result-order=ipv4first \
+APP_VARIANT=development \
+npx expo start --dev-client --host localhost
+```
+
+The first native build compiles the CocoaPods dependency graph and can take
+several minutes. Always open the `.xcworkspace`, not the `.xcodeproj`, after
+pods are installed.
+
 Basic ballot creation uses a native SecureStore module and is disabled on Expo
 web. Rebuild a development client after adding or updating that dependency. If
 encrypted storage is unavailable, the client refuses to create a ballot. If
@@ -168,6 +199,16 @@ The staging package can coexist with production. It intentionally uses the
 production API until `https://staging.rankedchoices.com` is provisioned, as
 approved for the current migration phase. Change the staging profile's
 `EXPO_PUBLIC_API_BASE_URL` when that environment exists.
+
+Production and staging builds also declare verified `https` ballot links for
+their respective domains. The server-side files must be generated from the
+templates in `docs/mobile-association-files/` after the store account owner,
+Apple Team ID, and Google Play app-signing certificate are final. Development
+builds intentionally rely on the `rankedchoices://` scheme and do not claim a
+web domain.
+
+See `docs/mobile-release-checklist.md` for deployment, privacy, TestFlight,
+store-submission, and rollback gates.
 
 ### Crash reporting
 

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,14 +1,17 @@
 const variants = {
   development: {
     identifier: 'com.rankedchoices.dev',
+    linkHost: null,
     name: 'Ranked Choices (Dev)',
   },
   staging: {
     identifier: 'com.rankedchoices.app.staging',
+    linkHost: 'staging.rankedchoices.com',
     name: 'Ranked Choices (Staging)',
   },
   production: {
     identifier: 'com.rankedchoices.app',
+    linkHost: 'rankedchoices.com',
     name: 'Ranked Choices',
   },
 };
@@ -17,6 +20,7 @@ module.exports = ({ config }) => {
   const requestedVariant = process.env.APP_VARIANT || 'development';
   const variant = variants[requestedVariant] ? requestedVariant : 'development';
   const variantConfig = variants[variant];
+  const linkHost = variantConfig.linkHost;
   const sentryOrganization = process.env.SENTRY_ORG?.trim();
   const sentryProject = process.env.SENTRY_PROJECT?.trim();
   const plugins = [...(config.plugins || [])];
@@ -43,10 +47,31 @@ module.exports = ({ config }) => {
     android: {
       ...config.android,
       package: process.env.RCV_ANDROID_PACKAGE || variantConfig.identifier,
+      ...(linkHost
+        ? {
+            intentFilters: [
+              ...(config.android?.intentFilters || []),
+              {
+                action: 'VIEW',
+                autoVerify: true,
+                category: ['BROWSABLE', 'DEFAULT'],
+                data: [{ host: linkHost, pathPrefix: '/ballot/', scheme: 'https' }],
+              },
+            ],
+          }
+        : {}),
     },
     ios: {
       ...config.ios,
       bundleIdentifier: process.env.RCV_IOS_BUNDLE_IDENTIFIER || variantConfig.identifier,
+      ...(linkHost
+        ? {
+            associatedDomains: [
+              ...(config.ios?.associatedDomains || []),
+              `applinks:${linkHost}`,
+            ],
+          }
+        : {}),
     },
   };
 };

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -14,6 +14,7 @@ export default function RootLayout() {
           contentStyle: { backgroundColor: '#f5f7fa' },
         }}>
         <Stack.Screen name="index" options={{ title: 'Ranked Choices' }} />
+        <Stack.Screen name="about" options={{ title: 'Privacy & support' }} />
         <Stack.Screen name="create" options={{ title: 'Create ballot' }} />
         <Stack.Screen name="ballot/[key]/index" options={{ title: 'Ballot' }} />
       </Stack>

--- a/apps/mobile/src/app/about.tsx
+++ b/apps/mobile/src/app/about.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import {
+  PRIVACY_POLICY_URL,
+  SOURCE_CODE_URL,
+  SUPPORT_EMAIL,
+  SUPPORT_URL,
+  TERMS_OF_SERVICE_URL,
+} from '@/config/service-links';
+
+type ResourceLinkProps = {
+  description: string;
+  label: string;
+  onPress: () => void;
+};
+
+function ResourceLink({ description, label, onPress }: ResourceLinkProps) {
+  return (
+    <Pressable
+      accessibilityHint={description}
+      accessibilityRole="link"
+      onPress={onPress}
+      style={({ pressed }) => [styles.resource, pressed && styles.pressed]}>
+      <Text style={styles.resourceLabel}>{label}</Text>
+      <Text style={styles.resourceDescription}>{description}</Text>
+    </Pressable>
+  );
+}
+
+export default function AboutScreen() {
+  const [error, setError] = useState('');
+
+  const open = async (url: string) => {
+    setError('');
+    try {
+      await Linking.openURL(url);
+    } catch {
+      setError(`That link could not be opened. Contact ${SUPPORT_EMAIL} for help.`);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.scrollContent} style={styles.screen}>
+      <View style={styles.content}>
+        <Text style={styles.eyebrow}>RANKED CHOICES</Text>
+        <Text style={styles.title}>Privacy & support</Text>
+        <Text style={styles.introduction}>
+          Learn how ballot and device data are handled, review the terms, contact support, or
+          inspect the open-source project.
+        </Text>
+
+        {error ? (
+          <Text accessibilityLiveRegion="assertive" style={styles.error}>
+            {error}
+          </Text>
+        ) : null}
+
+        <View style={styles.card}>
+          <ResourceLink
+            description="How Ranked Choices collects, uses, retains, and protects data"
+            label="Privacy policy"
+            onPress={() => void open(PRIVACY_POLICY_URL)}
+          />
+          <ResourceLink
+            description="The rules for using Ranked Choices"
+            label="Terms of service"
+            onPress={() => void open(TERMS_OF_SERVICE_URL)}
+          />
+          <ResourceLink
+            description={`Email ${SUPPORT_EMAIL}`}
+            label="Contact support"
+            onPress={() => void open(SUPPORT_URL)}
+          />
+          <ResourceLink
+            description="View the source code and report issues on GitHub"
+            label="Open-source project"
+            onPress={() => void open(SOURCE_CODE_URL)}
+          />
+        </View>
+
+        <Text selectable style={styles.email}>
+          Support: {SUPPORT_EMAIL}
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: '#f5f7fa' },
+  scrollContent: { padding: 22 },
+  content: { alignSelf: 'center', maxWidth: 620, width: '100%' },
+  eyebrow: { color: '#b24c00', fontSize: 12, fontWeight: '800', letterSpacing: 1.2 },
+  title: { color: '#12355b', fontSize: 32, fontWeight: '800', lineHeight: 38, marginTop: 8 },
+  introduction: { color: '#40556b', fontSize: 16, lineHeight: 24, marginTop: 12 },
+  error: {
+    backgroundColor: '#fff1ef',
+    borderRadius: 10,
+    color: '#81261f',
+    fontSize: 14,
+    lineHeight: 20,
+    marginTop: 18,
+    padding: 12,
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: 18,
+    marginTop: 24,
+    overflow: 'hidden',
+  },
+  resource: {
+    borderBottomColor: '#dce3e9',
+    borderBottomWidth: 1,
+    minHeight: 84,
+    paddingHorizontal: 20,
+    paddingVertical: 16,
+  },
+  resourceLabel: { color: '#12355b', fontSize: 17, fontWeight: '800' },
+  resourceDescription: { color: '#52697f', fontSize: 14, lineHeight: 20, marginTop: 4 },
+  pressed: { opacity: 0.7 },
+  email: { color: '#52697f', fontSize: 14, marginTop: 18, textAlign: 'center' },
+});

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -71,6 +71,14 @@ export default function HomeScreen() {
             style={({ pressed }) => [styles.createButton, pressed && styles.buttonPressed]}>
             <Text style={styles.createButtonText}>Create a basic ballot</Text>
           </Pressable>
+
+          <Pressable
+            accessibilityHint="Opens privacy, terms, contact, and source-code information"
+            accessibilityRole="link"
+            onPress={() => router.push('./about')}
+            style={({ pressed }) => [styles.aboutLink, pressed && styles.buttonPressed]}>
+            <Text style={styles.aboutLinkText}>Privacy & support</Text>
+          </Pressable>
         </View>
       </SafeAreaView>
     </KeyboardAvoidingView>
@@ -180,5 +188,16 @@ const styles = StyleSheet.create({
     color: '#146c43',
     fontSize: 16,
     fontWeight: '800',
+  },
+  aboutLink: {
+    alignSelf: 'center',
+    marginTop: 22,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  aboutLinkText: {
+    color: '#40556b',
+    fontSize: 14,
+    textDecorationLine: 'underline',
   },
 });

--- a/apps/mobile/src/components/about-screen.test.tsx
+++ b/apps/mobile/src/components/about-screen.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import AboutScreen from '@/app/about';
+
+describe('AboutScreen', () => {
+  it('renders accessible privacy and support resources', () => {
+    const html = renderToStaticMarkup(<AboutScreen />);
+
+    expect(html).toContain('Privacy &amp; support');
+    expect(html).toContain('Privacy policy');
+    expect(html).toContain('Terms of service');
+    expect(html).toContain('Contact support');
+    expect(html).toContain('Open-source project');
+    expect(html.match(/role="link"/g)).toHaveLength(4);
+  });
+});

--- a/apps/mobile/src/config/app-config.test.ts
+++ b/apps/mobile/src/config/app-config.test.ts
@@ -10,9 +10,17 @@ type ExpoConfigInput = {
 };
 
 type ExpoConfigResult = {
-  android: { package: string };
+  android: {
+    intentFilters?: {
+      action: string;
+      autoVerify: boolean;
+      category: string[];
+      data: { host: string; pathPrefix: string; scheme: string }[];
+    }[];
+    package: string;
+  };
   extra: { buildVariant: string };
-  ios: { bundleIdentifier: string };
+  ios: { associatedDomains?: string[]; bundleIdentifier: string };
   name: string;
   plugins: unknown[];
 };
@@ -57,10 +65,32 @@ describe('mobile app build variants', () => {
   });
 
   it('uses the development identity for an unset or invalid variant', () => {
-    expect(resolveConfig().android.package).toBe('com.rankedchoices.dev');
+    const development = resolveConfig();
+    expect(development.android.package).toBe('com.rankedchoices.dev');
+    expect(development.android.intentFilters).toBeUndefined();
+    expect(development.ios.associatedDomains).toBeUndefined();
 
     process.env.APP_VARIANT = 'unexpected';
     expect(resolveConfig().extra.buildVariant).toBe('development');
+  });
+
+  it.each([
+    ['staging', 'staging.rankedchoices.com'],
+    ['production', 'rankedchoices.com'],
+  ])('configures verified ballot links for %s', (variant, host) => {
+    process.env.APP_VARIANT = variant;
+
+    const config = resolveConfig();
+
+    expect(config.ios.associatedDomains).toEqual([`applinks:${host}`]);
+    expect(config.android.intentFilters).toEqual([
+      {
+        action: 'VIEW',
+        autoVerify: true,
+        category: ['BROWSABLE', 'DEFAULT'],
+        data: [{ host, pathPrefix: '/ballot/', scheme: 'https' }],
+      },
+    ]);
   });
 
   it('preserves explicit platform identifier overrides', () => {

--- a/apps/mobile/src/config/association-files.test.ts
+++ b/apps/mobile/src/config/association-files.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import androidAssociation from '../../../../docs/mobile-association-files/assetlinks.template.json';
+import appleAssociation from '../../../../docs/mobile-association-files/apple-app-site-association.template.json';
+
+describe('mobile association templates', () => {
+  it('limits the Apple association to production ballot links', () => {
+    expect(appleAssociation).toEqual({
+      applinks: {
+        details: [
+          {
+            appIDs: ['APPLE_TEAM_ID.com.rankedchoices.app'],
+            components: [
+              {
+                '/': '/ballot/*',
+                comment: 'Open public Ranked Choices ballot links in the production app.',
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('uses the Play app-signing placeholder for the production package', () => {
+    expect(androidAssociation).toEqual([
+      {
+        relation: ['delegate_permission/common.handle_all_urls'],
+        target: {
+          namespace: 'android_app',
+          package_name: 'com.rankedchoices.app',
+          sha256_cert_fingerprints: ['ANDROID_RELEASE_SHA256_FINGERPRINT'],
+        },
+      },
+    ]);
+  });
+});

--- a/apps/mobile/src/config/service-links.test.ts
+++ b/apps/mobile/src/config/service-links.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PRIVACY_POLICY_URL,
+  SOURCE_CODE_URL,
+  SUPPORT_EMAIL,
+  SUPPORT_URL,
+  TERMS_OF_SERVICE_URL,
+} from './service-links';
+
+describe('service links', () => {
+  it('uses public HTTPS pages for legal and source information', () => {
+    expect(new URL(PRIVACY_POLICY_URL)).toMatchObject({
+      hostname: 'rankedchoices.com',
+      pathname: '/privacy-policy.html',
+      protocol: 'https:',
+    });
+    expect(new URL(TERMS_OF_SERVICE_URL)).toMatchObject({
+      hostname: 'rankedchoices.com',
+      pathname: '/terms-of-service.html',
+      protocol: 'https:',
+    });
+    expect(new URL(SOURCE_CODE_URL)).toMatchObject({
+      hostname: 'github.com',
+      protocol: 'https:',
+    });
+  });
+
+  it('builds the support mail link from the displayed address', () => {
+    expect(SUPPORT_URL).toBe(
+      `mailto:${SUPPORT_EMAIL}?subject=Ranked%20Choices%20support`,
+    );
+  });
+});

--- a/apps/mobile/src/config/service-links.ts
+++ b/apps/mobile/src/config/service-links.ts
@@ -1,0 +1,5 @@
+export const PRIVACY_POLICY_URL = 'https://rankedchoices.com/privacy-policy.html';
+export const TERMS_OF_SERVICE_URL = 'https://rankedchoices.com/terms-of-service.html';
+export const SOURCE_CODE_URL = 'https://github.com/DavidMoritz/rcv';
+export const SUPPORT_EMAIL = 'davidmoritz@gmail.com';
+export const SUPPORT_URL = `mailto:${SUPPORT_EMAIL}?subject=Ranked%20Choices%20support`;

--- a/docs/expo-migration-rfc.md
+++ b/docs/expo-migration-rfc.md
@@ -2,7 +2,7 @@
 
 - Status: Accepted; Phases 0 and 1 implemented; Phase 2 in progress
 - Date: 2026-08-08
-- Last updated: 2026-09-06
+- Last updated: 2026-09-07
 - Proposer: Emmanuel Jones
 - Decision horizon: architecture and first product milestone
 - Maintainer guidance received: 2026-08-30 and 2026-09-05
@@ -517,5 +517,18 @@ deferred:
 ## Review gates
 
 Phase 0 received maintainer approval and the read-only device spike is
-complete. Revisit this RFC before production link association, during
-app-store preparation, and again before Phase 3 authentication work.
+complete. Phase 2's guest create -> store credential -> open ballot -> vote ->
+results path has now passed on both Android and an iOS simulator against the
+real local PHP/MySQL backend. Xcode MCP also completed a clean native iOS build.
+
+Production distribution follows `docs/mobile-release-checklist.md`. Store
+account ownership must be settled before registering or uploading the
+production identifiers. The app-side production/staging link declarations and
+non-deployable association templates may be reviewed in advance, but the
+server files require the final Apple Team ID and Google Play app-signing
+fingerprint. The privacy policy, support path, production API deployment,
+association files, signed physical-device testing, and TestFlight/Play internal
+testing are release gates.
+
+Revisit this RFC during store-account setup and again before Phase 3
+authentication work.

--- a/docs/mobile-association-files/README.md
+++ b/docs/mobile-association-files/README.md
@@ -1,0 +1,33 @@
+# Mobile link association files
+
+These files are templates, not deployable production configuration. Keeping
+them outside `src/` prevents a placeholder Apple Team ID or Android signing
+fingerprint from being published accidentally.
+
+Before deploying production verified links:
+
+1. Confirm the durable App Store and Play Console account owners.
+2. Register `com.rankedchoices.app` in the selected Apple team and replace
+   `APPLE_TEAM_ID` in `apple-app-site-association.template.json` with that
+   team's ten-character Team ID.
+3. Create or select the final Google Play App Signing identity and replace
+   `ANDROID_RELEASE_SHA256_FINGERPRINT` in `assetlinks.template.json` with the
+   SHA-256 fingerprint shown by Play Console for the app-signing certificate,
+   not an upload or local debug certificate.
+4. Remove `.template.json` from the deployed filenames and publish them as:
+
+   ```text
+   https://rankedchoices.com/.well-known/apple-app-site-association
+   https://rankedchoices.com/.well-known/assetlinks.json
+   ```
+
+5. Serve both files directly over HTTPS with no redirect. Serve the Apple file
+   as `application/json`; use `application/json` for Android as well.
+6. Replace every placeholder and validate the deployed JSON before installing
+   a newly signed production build. A build installed before association is
+   corrected may retain a failed verification result until reinstall.
+
+The production app configuration claims only `https://rankedchoices.com/ballot/*`.
+The staging app claims the equivalent path on `staging.rankedchoices.com` so
+the two installed apps do not compete for the production domain. Create
+separate staging association files when that host is provisioned.

--- a/docs/mobile-association-files/apple-app-site-association.template.json
+++ b/docs/mobile-association-files/apple-app-site-association.template.json
@@ -1,0 +1,17 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [
+          "APPLE_TEAM_ID.com.rankedchoices.app"
+        ],
+        "components": [
+          {
+            "/": "/ballot/*",
+            "comment": "Open public Ranked Choices ballot links in the production app."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/mobile-association-files/assetlinks.template.json
+++ b/docs/mobile-association-files/assetlinks.template.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.rankedchoices.app",
+      "sha256_cert_fingerprints": [
+        "ANDROID_RELEASE_SHA256_FINGERPRINT"
+      ]
+    }
+  }
+]

--- a/docs/mobile-release-checklist.md
+++ b/docs/mobile-release-checklist.md
@@ -1,0 +1,159 @@
+# Mobile release checklist
+
+This checklist governs the first public iOS and Android releases. Complete the
+staging and TestFlight/internal-testing gates before App Store or Play Store
+review. Do not place passwords, signing keys, management tokens, voter codes,
+or store API credentials in the repository.
+
+## 1. Ownership and access
+
+- [ ] The maintainer has recorded which durable legal person or entity owns
+  the App Store Connect and Google Play Console listings.
+- [ ] The selected accounts, rather than a temporary contributor account, own
+  the production identifiers and signing identities.
+- [ ] Release contributors have least-privilege App Manager/Developer access;
+  the Account Holder retains agreements, renewal, and recovery responsibility.
+- [ ] The support email, privacy-request contact, copyright holder, and public
+  seller/developer names have been approved.
+
+Safety check: verify the account/team name in each store before registering
+`com.rankedchoices.app` or uploading any build. Moving an app later is possible
+only under store-specific eligibility rules and should not be the launch plan.
+
+## 2. Backend deployment
+
+- [ ] Back up the production database and record a restore point.
+- [ ] Apply every migration in `src/api/migrations/` in filename order. For the
+  guest-creation slice, apply `2026-09-06-ballot-management-tokens.sql` before
+  deploying `src/api/v2/ballots.php`.
+- [ ] Run the preflight and post-deploy queries in `src/api/SETUP.md`; confirm
+  the management-token table, unique digest index, and ballot lookup index.
+- [ ] Deploy the v2 ballot, vote, and results endpoints plus their guarded
+  legacy dependencies.
+- [ ] Verify GET requests receive the documented method/error envelope and run
+  a disposable production smoke ballot approved by the maintainer. Remove all
+  smoke data after verification.
+- [ ] Confirm the existing AngularJS create, vote, results, and management
+  smoke flows still pass.
+
+Safety check: the schema migration is additive and idempotent. Keep the new
+endpoint code unavailable until its table exists. If an endpoint fails, roll
+back the code first; retaining an unused additive table is safer than dropping
+it during an incident.
+
+## 3. Staging and build configuration
+
+- [ ] Provision `https://staging.rankedchoices.com` with a non-production
+  database and the same migration level as production.
+- [ ] Change the staging EAS API target from production to staging.
+- [ ] Create EAS projects/environments under the durable project owner.
+- [ ] Store signing material and any Sentry source-map token in store/EAS
+  credential systems, never source control.
+- [ ] Confirm development, staging, and production builds have distinct names,
+  identifiers, API targets, icons, and update channels.
+- [ ] Decide whether Sentry will be enabled. If yes, approve the privacy-policy
+  language, set a retention period, configure the privacy-minimized project,
+  and verify one symbolicated test error without ballot or voter data.
+
+Safety check: print the resolved Expo configuration for each build variant and
+inspect its identifier, associated domain, and telemetry flags; separately
+inspect the matching EAS profile's API URL before building. A staging binary
+must never be submitted as production.
+
+## 4. Verified links
+
+- [ ] Fill the templates in `docs/mobile-association-files/` only after the
+  Apple Team ID and Google Play app-signing SHA-256 fingerprint are final.
+- [ ] Publish the production files beneath
+  `https://rankedchoices.com/.well-known/` with HTTPS, JSON content types, and
+  no redirect.
+- [ ] Publish separate staging files on `staging.rankedchoices.com`.
+- [ ] Verify an ordinary browser still opens every ballot URL as a fallback.
+- [ ] On clean physical-device installs, verify a production-domain ballot
+  link opens the production app and a staging-domain link opens only staging.
+
+Safety check: inspect the served files from an external network and compare the
+Team ID, package, and certificate fingerprint with the store consoles. Test
+universal/app links after reinstalling, because failed association checks can
+be cached by the device.
+
+## 5. Privacy, support, and store metadata
+
+- [ ] The maintainer reviews `src/privacy-policy.html` against actual hosting,
+  log, backup, analytics, Sentry, and deletion practices and obtains legal
+  review if appropriate.
+- [ ] The privacy policy and terms pages are live before any store build points
+  to them; the mobile Privacy & support screen opens both.
+- [ ] App Store and Play data-safety answers match the code and policy,
+  including ballot/vote content, IP addresses, optional installation IDs,
+  group answers, secure codes, diagnostics, and website-only analytics.
+- [ ] Support URL/email, description, keywords, category, age rating,
+  copyright, review notes, and geographic availability are approved.
+- [ ] Screenshots contain only disposable ballots and no personal, voter-code,
+  management-token, production-account, or private test information.
+- [ ] Export-compliance answers are reviewed for HTTPS and SecureStore usage.
+
+Safety check: have one reviewer trace every privacy disclosure back to code or
+an operating practice and a second reviewer compare the final store forms with
+the published policy.
+
+## 6. Automated and device verification
+
+- [ ] Root Vitest, PHPUnit, Playwright, live MySQL contracts, and production
+  Vite build pass from the release commit.
+- [ ] Mobile Vitest, TypeScript, Expo lint, and static export pass.
+- [ ] Xcode builds the production scheme without errors or unresolved signing
+  warnings; Android produces a signed release bundle.
+- [ ] Android device E2E covers incoming link -> rank -> submit -> results,
+  secure code, grouping questions, sharing, and guest creation.
+- [ ] iOS simulator and at least one physical iPhone cover lookup, guest
+  creation, SecureStore recovery messaging, voting, results, sharing, cold
+  launch links, network failure/retry, larger text, and VoiceOver basics.
+- [ ] Test current and oldest supported OS versions where practical.
+
+Safety check: use disposable records and record the shortcode or database ID
+before each mutation so cleanup targets only test data. Never capture raw
+management tokens in screenshots, logs, CI artifacts, or bug reports.
+
+## 7. TestFlight and Play internal testing
+
+- [ ] Upload signed release candidates and resolve all processing, privacy,
+  compliance, and symbol warnings.
+- [ ] Run internal testing first, then a small external TestFlight/closed Play
+  group using the production-like backend and link files.
+- [ ] Provide reviewers a live disposable ballot, secure-code instructions,
+  and concise notes explaining that accounts and advanced management remain on
+  the website.
+- [ ] Collect crash-free launch, link-open, vote completion, and support
+  feedback without enabling product analytics.
+- [ ] Obtain maintainer sign-off on the exact build numbers selected for
+  review.
+
+Safety check: upload does not authorize release. Keep manual release control
+for version 1.0 so approval cannot publish an unreviewed backend/build pairing.
+
+## 8. Public release and rollback
+
+- [ ] Re-run external API, policy/support URL, and association-file checks
+  immediately before submission and release.
+- [ ] Publish a small initial availability set or manual/phased release chosen
+  by the maintainer.
+- [ ] Monitor crashes, support requests, API errors, and vote completion during
+  the overlap period while the website remains the fallback.
+- [ ] Document who can pause availability, disable mobile endpoints, rotate
+  signing/store credentials, and communicate an incident.
+- [ ] Keep the website operational; do not begin AngularJS retirement based on
+  the first native release.
+
+Rollback order: stop or pause store rollout, disable only the affected new API
+surface if necessary, keep canonical web links functional, and preserve data
+for diagnosis. Do not drop additive schema during an active rollback.
+
+## References
+
+- [Apple Developer Program enrollment](https://developer.apple.com/help/account/membership/program-enrollment/)
+- [App Store Connect accounts and roles](https://developer.apple.com/help/app-store-connect/manage-your-team/overview-of-accounts-and-roles/)
+- [TestFlight overview](https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview)
+- [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [Apple app-transfer criteria](https://developer.apple.com/help/app-store-connect/transfer-an-app/app-transfer-criteria)
+- [Expo app-store submission](https://docs.expo.dev/submit/ios/)

--- a/src/index.html
+++ b/src/index.html
@@ -133,6 +133,10 @@
         >
         <small
           >&copy; 2016-2026 Ranked Choices Vote Calculator &bull;
+          <a href="https://rankedchoices.com/privacy-policy.html" target="_blank"
+            >Privacy Policy</a
+          >
+          &bull;
           <a href="https://rankedchoices.com/terms-of-service.html" target="_blank"
             >Terms of Service</a
           ></small

--- a/src/pages/about.html
+++ b/src/pages/about.html
@@ -67,6 +67,18 @@
     <div class="row about-grid">
       <div class="col-sm-6">
         <div class="about-card">
+          <h4><i class="fa fa-user-secret text-primary"></i> Privacy</h4>
+          <p>
+            Review the
+            <a href="https://rankedchoices.com/privacy-policy.html" target="_blank"
+              >Privacy Policy</a
+            >
+            to learn how ballot, vote, account, device, and diagnostic data are handled.
+          </p>
+        </div>
+      </div>
+      <div class="col-sm-6">
+        <div class="about-card">
           <h4><i class="fa fa-user-plus text-success"></i> Get more — for free</h4>
           <p>
             Creating a <strong>free</strong> account lets you edit entries, manage your ballots, and

--- a/src/privacy-policy.html
+++ b/src/privacy-policy.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="index,follow">
+  <title>Privacy Policy - Ranked Choices</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      background: #f5f7fa;
+      color: #263b4f;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.65;
+      margin: 0;
+    }
+    main {
+      background: #fff;
+      margin: 0 auto;
+      max-width: 820px;
+      min-height: 100vh;
+      padding: 48px 32px 64px;
+    }
+    h1, h2 { color: #12355b; line-height: 1.25; }
+    h1 { border-bottom: 3px solid #146c43; font-size: 32px; margin-bottom: 6px; padding-bottom: 14px; }
+    h2 { font-size: 21px; margin-top: 34px; }
+    a { color: #075eb5; }
+    li { margin-bottom: 9px; }
+    .effective { color: #52697f; font-size: 14px; margin-top: 0; }
+    .summary { background: #e8f2ed; border-radius: 12px; color: #294f3c; padding: 16px 18px; }
+    @media (max-width: 600px) {
+      main { padding: 28px 20px 48px; }
+      h1 { font-size: 27px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Privacy Policy</h1>
+  <p class="effective">Effective September 7, 2026</p>
+
+  <p class="summary">
+    Ranked Choices is a free, open-source service for creating and participating in ranked-choice
+    ballots. We do not sell personal information. This policy explains the information handled by
+    RankedChoices.com and the Ranked Choices mobile apps.
+  </p>
+
+  <h2>Information you provide</h2>
+  <ul>
+    <li>
+      <strong>Ballot content:</strong> ballot names, candidate names, configuration, and other
+      content supplied by ballot organizers.
+    </li>
+    <li>
+      <strong>Voting content:</strong> ranked candidate selections and, when an organizer enables
+      them, voter-code or group-question responses. Some website ballots may also request a voter
+      name.
+    </li>
+    <li>
+      <strong>Account information on the website:</strong> information such as a username, email
+      address, and profile image when you choose to register or use a supported sign-in provider.
+      The initial mobile app does not require an account.
+    </li>
+    <li>
+      <strong>Communications:</strong> information you include when contacting support or reporting
+      a problem.
+    </li>
+  </ul>
+
+  <h2>Information collected automatically</h2>
+  <ul>
+    <li>
+      The server records the network IP address associated with a submitted vote and may keep
+      ordinary web-server security and request logs.
+    </li>
+    <li>
+      The mobile app generates a random request identifier so a retried vote is not counted twice.
+      For a ballot whose organizer enables one-device-one-vote protection, the app also generates
+      a random installation identifier and sends it with the vote to detect another vote from that
+      installation. It is not an advertising identifier.
+    </li>
+    <li>
+      The website may use cookies needed for sessions and account features. It also currently uses
+      Google Analytics to understand website usage. The native app does not use product analytics.
+    </li>
+    <li>
+      If privacy-minimized mobile crash reporting is enabled for a release, technical diagnostics
+      may be processed by Sentry. Ranked Choices configures it not to send ballot names,
+      shortcodes, candidates, rankings, voter codes, email addresses, interaction recordings,
+      screenshots, application logs, or default personally identifying information.
+    </li>
+  </ul>
+
+  <h2>Information kept on your device</h2>
+  <p>
+    When a guest creates a ballot in the mobile app, the server returns a high-entropy management
+    credential once. The app stores that credential in encrypted device storage; the server stores
+    only a one-way digest. The app also stores its random installation identifier locally. Removing
+    the app or losing the device may remove access to an unclaimed guest ballot.
+  </p>
+
+  <h2>How information is used</h2>
+  <p>We use the information described above to:</p>
+  <ul>
+    <li>create, display, manage, and calculate ballot results;</li>
+    <li>accept votes and enforce organizer-selected voting rules;</li>
+    <li>prevent duplicate vote submissions and investigate abuse or security incidents;</li>
+    <li>operate, troubleshoot, and improve the service; and</li>
+    <li>respond to support requests and comply with legal obligations.</li>
+  </ul>
+
+  <h2>Visibility and sharing</h2>
+  <p>
+    A ballot's name, candidates, shortcode, and released results may be visible to anyone who can
+    access its link. Organizers control available ballot settings and should not enter sensitive
+    personal information in public ballot fields. Group responses, voter names, and secure codes
+    may be available to an authorized organizer under the applicable ballot settings.
+  </p>
+  <p>
+    We may disclose information to infrastructure providers that host or protect the service, to
+    Sentry if mobile crash reporting is enabled, and to Google Analytics for website analytics. We
+    may also disclose information when required by law, to protect the service or its users, or as
+    part of a transfer of the service. We do not sell personal information or use ballot content
+    for advertising.
+  </p>
+
+  <h2>Retention, deletion, and choices</h2>
+  <p>
+    Ballots and their associated votes are generally retained until the organizer deletes the
+    ballot or the service operator removes it. Website account information is generally retained
+    until the account is deleted. Operational logs, backups, and privacy-minimized crash reports
+    may remain for a limited period under the applicable provider's security and retention
+    practices.
+  </p>
+  <p>
+    Use the website's available ballot or account deletion controls, or contact us, to request
+    access, correction, or deletion. A request may require information sufficient to verify that
+    you control the affected account or ballot. We may retain information where necessary for
+    security, legal compliance, dispute resolution, or backup integrity. You may disable website
+    analytics using browser controls or applicable consent/opt-out mechanisms.
+  </p>
+
+  <h2>Security</h2>
+  <p>
+    We use reasonable safeguards appropriate to the service, including encrypted transport,
+    server-side validation, one-way management-token digests, and encrypted device storage for
+    guest management credentials. No storage or transmission system can be guaranteed completely
+    secure.
+  </p>
+
+  <h2>Children</h2>
+  <p>
+    Ranked Choices is not directed to children under 13. Do not knowingly submit personal
+    information about a child through a ballot. Contact us if you believe a child has provided
+    personal information so we can review and, where appropriate, delete it.
+  </p>
+
+  <h2>Changes to this policy</h2>
+  <p>
+    We may update this policy as the service changes. The effective date above will be revised when
+    changes are published. Material new data collection, including enabling a new analytics or
+    crash-reporting service, should be reflected here before it begins.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Questions, privacy requests, and support requests may be sent to
+    <a href="mailto:davidmoritz@gmail.com">davidmoritz@gmail.com</a>. You can also inspect the
+    source or report a technical issue in the
+    <a href="https://github.com/DavidMoritz/rcv">Ranked Choices GitHub repository</a>.
+  </p>
+</main>
+</body>
+</html>

--- a/src/terms-of-service.html
+++ b/src/terms-of-service.html
@@ -62,6 +62,7 @@
 <div class="container">
   <h1>TERMS OF USE</h1>
   <p style="color:#888; font-size:13px; margin-bottom:4px;">Version 2.9.24</p>
+  <p>See the <a href="https://rankedchoices.com/privacy-policy.html">Privacy Policy</a> for how the website and mobile apps handle information.</p>
   <p>Thanks for stopping by! These Terms of Use set out the rules for your use of this app / access to this website. Before using rankedchoices.com, you're required to read and agreed to these Terms of Use.  Remember that just by using rankedchoices.com, you're automatically agreeing to all of these terms and conditions. </p>
   <h4>Basics:</h4>
   <ol>

--- a/vite.config.js
+++ b/vite.config.js
@@ -144,6 +144,10 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'privacy-policy.html',
+          dest: '.'
+        },
+        {
           src: 'secure-elections-instructions.html',
           dest: '.'
         },


### PR DESCRIPTION
## Summary

- add a public privacy-policy page plus an accessible native Privacy & support screen
- declare production/staging universal and app links while keeping development unassociated
- add non-deployable Apple and Android association templates with placeholder-safety tests
- document verified iOS setup and the end-to-end store release, rollout, and rollback gates
- update the Expo RFC with completed Android/iOS verification and remaining launch prerequisites

## Safety and scope

The association templates deliberately remain outside the deployable web tree. They require the final Apple Team ID and Google Play app-signing fingerprint. This PR does not register store identities, publish association files, deploy APIs, upload builds, or authorize a public release. The maintainer must review the privacy language against actual operating practices before deployment.

## Verification

- npm test: 191 Vitest tests and 231 PHPUnit tests / 587 assertions passed
- npm run build passed; privacy-policy.html copied into dist
- npm run test:e2e: all 3 Playwright browser flows passed
- mobile: 69 Vitest tests, TypeScript, Expo lint, and static web export passed
- resolved Expo configs checked for development, staging, and production identities/link declarations
- Xcode MCP build passed with zero errors on Xcode 26.6 / iOS 26.5 simulator
- simulator rendered and navigated the new accessible Privacy & support screen

## Known launch blockers

- production API v2 ballot/vote endpoints are not deployed
- rankedchoices.com association files are not published
- durable store-account ownership, Apple Team ID, and Play signing fingerprint are not final
- staging, signed physical-device testing, privacy review, TestFlight, and Play internal testing remain release gates