### PR TITLE
Prepare mobile app store submission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,5 +73,8 @@ jobs:
       - name: Lint mobile app
         run: npm run lint
 
+      - name: Validate release metadata and configuration
+        run: npm run validate:release
+
       - name: Verify Expo web export
         run: npx expo export --platform web

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -210,6 +210,27 @@ web domain.
 See `docs/mobile-release-checklist.md` for deployment, privacy, TestFlight,
 store-submission, and rollback gates.
 
+### Store preparation
+
+Versioned release material lives under `store/`:
+
+- `metadata/en-US.json` is the source for the initial English store copy and
+  screenshot captions; and
+- `release-status.json` records decisions that are settled and manual gates
+  that still block a signed beta or public release.
+
+Run `npm run validate:release` during ordinary development to check version
+numbers, build variants, verified-link declarations, store character limits,
+safe association placeholders, and the required content-safety controls. CI
+runs the same command. Immediately before a release, run
+`npm run validate:release:strict`; it intentionally fails while any recorded
+manual blocker remains.
+
+The fuller copy review, screenshot plan, provisional privacy/data-safety
+matrix, moderation requirements, and private reviewer-note draft are in
+`docs/mobile-store-submission.md`. The current Expo placeholder icon is not a
+production asset.
+
 ### Crash reporting
 
 The official Sentry React Native SDK and source-map-aware Metro configuration

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,15 +2,18 @@
   "expo": {
     "name": "Ranked Choices",
     "slug": "ranked-choices",
+    "description": "Create and participate in ranked-choice ballots, then view round-by-round results.",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "rankedchoices",
     "userInterfaceStyle": "automatic",
     "ios": {
+      "buildNumber": "1",
       "icon": "./assets/expo.icon"
     },
     "android": {
+      "versionCode": 1,
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,7 +38,9 @@
     "lint": "expo lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:android:e2e": "node scripts/android-phase1-e2e.mjs"
+    "test:android:e2e": "node scripts/android-phase1-e2e.mjs",
+    "validate:release": "node scripts/validate-release-readiness.mjs",
+    "validate:release:strict": "node scripts/validate-release-readiness.mjs --strict"
   },
   "private": true
 }

--- a/apps/mobile/scripts/validate-release-readiness.mjs
+++ b/apps/mobile/scripts/validate-release-readiness.mjs
@@ -1,0 +1,172 @@
+import { createRequire } from 'node:module';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const mobileRoot = resolve(scriptDirectory, '..');
+const repositoryRoot = resolve(mobileRoot, '../..');
+const require = createRequire(import.meta.url);
+
+const loadJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+const appJson = loadJson(join(mobileRoot, 'app.json')).expo;
+const packageJson = loadJson(join(mobileRoot, 'package.json'));
+const eas = loadJson(join(mobileRoot, 'eas.json'));
+const metadata = loadJson(join(mobileRoot, 'store/metadata/en-US.json'));
+const releaseStatus = loadJson(join(mobileRoot, 'store/release-status.json'));
+const configureApp = require(join(mobileRoot, 'app.config.js'));
+
+const failures = [];
+const check = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+const isHttpsUrl = (value) => {
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+const utf8Length = (value) => Buffer.byteLength(value, 'utf8');
+
+check(/^\d+\.\d+\.\d+$/.test(appJson.version), 'Expo version must use x.y.z format.');
+check(packageJson.version === appJson.version, 'package.json and app.json versions must match.');
+check(/^\d+$/.test(appJson.ios?.buildNumber ?? ''), 'iOS buildNumber must be numeric.');
+check(Number.isInteger(appJson.android?.versionCode) && appJson.android.versionCode > 0,
+  'Android versionCode must be a positive integer.');
+
+const expectedVariants = {
+  development: { identifier: 'com.rankedchoices.dev', host: null },
+  staging: { identifier: 'com.rankedchoices.app.staging', host: 'staging.rankedchoices.com' },
+  production: { identifier: 'com.rankedchoices.app', host: 'rankedchoices.com' },
+};
+
+const identifierOverrides = {
+  RCV_ANDROID_PACKAGE: process.env.RCV_ANDROID_PACKAGE,
+  RCV_IOS_BUNDLE_IDENTIFIER: process.env.RCV_IOS_BUNDLE_IDENTIFIER,
+};
+delete process.env.RCV_ANDROID_PACKAGE;
+delete process.env.RCV_IOS_BUNDLE_IDENTIFIER;
+
+for (const [variant, expected] of Object.entries(expectedVariants)) {
+  const previousVariant = process.env.APP_VARIANT;
+  process.env.APP_VARIANT = variant;
+  const resolved = configureApp({ config: structuredClone(appJson) });
+  if (previousVariant === undefined) delete process.env.APP_VARIANT;
+  else process.env.APP_VARIANT = previousVariant;
+
+  check(resolved.ios?.bundleIdentifier === expected.identifier,
+    `${variant} iOS identifier must be ${expected.identifier}.`);
+  check(resolved.android?.package === expected.identifier,
+    `${variant} Android package must be ${expected.identifier}.`);
+
+  const domains = resolved.ios?.associatedDomains ?? [];
+  const filters = resolved.android?.intentFilters ?? [];
+  if (expected.host) {
+    check(domains.includes(`applinks:${expected.host}`),
+      `${variant} must claim the expected iOS associated domain.`);
+    check(filters.some((filter) => filter.data?.some((data) =>
+      data.scheme === 'https' && data.host === expected.host && data.pathPrefix === '/ballot/')),
+    `${variant} must claim only the canonical Android ballot path.`);
+  } else {
+    check(domains.length === 0 && filters.length === 0,
+      'Development builds must not claim a verified web domain.');
+  }
+
+  check(eas.build?.[variant]?.env?.APP_VARIANT === variant,
+    `EAS ${variant} profile must set its matching APP_VARIANT.`);
+}
+
+for (const [name, value] of Object.entries(identifierOverrides)) {
+  if (value !== undefined) process.env[name] = value;
+}
+
+check(eas.build?.production?.env?.EXPO_PUBLIC_API_BASE_URL === 'https://rankedchoices.com/api',
+  'Production EAS profile must target the production HTTPS API.');
+const stagingTargetsProduction =
+  eas.build?.staging?.env?.EXPO_PUBLIC_API_BASE_URL === 'https://rankedchoices.com/api';
+check(!stagingTargetsProduction || releaseStatus.blockers.some(({ id }) => id === 'staging-environment'),
+  'A production-targeting staging profile must remain recorded as a release blocker.');
+
+check(utf8Length(metadata.shared.appName) <= 30, 'Store app name exceeds 30 characters.');
+check(utf8Length(metadata.apple.subtitle) <= 30, 'Apple subtitle exceeds 30 characters.');
+check(utf8Length(metadata.apple.promotionalText) <= 170,
+  'Apple promotional text exceeds 170 characters.');
+check(utf8Length(metadata.apple.description) <= 4000,
+  'Apple description exceeds 4,000 characters.');
+check(utf8Length(metadata.apple.keywords) <= 100, 'Apple keywords exceed 100 bytes.');
+check(utf8Length(metadata.googlePlay.shortDescription) <= 80,
+  'Play short description exceeds 80 characters.');
+check(utf8Length(metadata.googlePlay.fullDescription) <= 4000,
+  'Play full description exceeds 4,000 characters.');
+
+for (const [label, url] of Object.entries({
+  appleSupport: metadata.apple.supportUrl,
+  appleMarketing: metadata.apple.marketingUrl,
+  applePrivacy: metadata.apple.privacyPolicyUrl,
+  playWebsite: metadata.googlePlay.website,
+  playPrivacy: metadata.googlePlay.privacyPolicyUrl,
+})) {
+  check(isHttpsUrl(url), `${label} must be a valid HTTPS URL.`);
+}
+
+check(metadata.screenshots.length >= 4, 'At least four screenshot scenes must be planned.');
+check(metadata.screenshots.every((item, index) => item.order === index + 1),
+  'Screenshot order values must be consecutive and start at one.');
+check(metadata.screenshots.every((item) => item.altText && item.altText.length <= 140),
+  'Every screenshot must have concise alt text (140 characters or fewer).');
+
+const appleAssociation = readFileSync(
+  join(repositoryRoot, 'docs/mobile-association-files/apple-app-site-association.template.json'),
+  'utf8',
+);
+const androidAssociation = readFileSync(
+  join(repositoryRoot, 'docs/mobile-association-files/assetlinks.template.json'),
+  'utf8',
+);
+check(appleAssociation.includes('APPLE_TEAM_ID'), 'Apple association template lost its safe placeholder.');
+check(androidAssociation.includes('ANDROID_RELEASE_SHA256_FINGERPRINT'),
+  'Android association template lost its safe placeholder.');
+
+const placeholderPatterns = ['APPLE_TEAM_ID', 'ANDROID_RELEASE_SHA256_FINGERPRINT'];
+const scanDeployableFiles = (directory) => {
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) scanDeployableFiles(path);
+    else {
+      const bytes = readFileSync(path);
+      for (const placeholder of placeholderPatterns) {
+        check(!bytes.includes(Buffer.from(placeholder)),
+          `Deployable source contains association placeholder ${placeholder}: ${path}`);
+      }
+    }
+  }
+};
+scanDeployableFiles(join(repositoryRoot, 'src'));
+
+const blockerIds = releaseStatus.blockers.map(({ id }) => id);
+check(new Set(blockerIds).size === blockerIds.length, 'Release blocker IDs must be unique.');
+check(releaseStatus.blockers.every(({ gate, owner, summary }) => gate && owner && summary),
+  'Every release blocker needs a gate, owner, and summary.');
+
+const createScreen = readFileSync(join(mobileRoot, 'src/app/create.tsx'), 'utf8');
+const ballotScreen = readFileSync(join(mobileRoot, 'src/app/ballot/[key]/index.tsx'), 'utf8');
+check(createScreen.includes('<TermsAcceptance'), 'Create flow must retain explicit terms acceptance.');
+check(ballotScreen.includes('<BallotReportLink'), 'Ballot screen must retain its reporting action.');
+
+if (failures.length) {
+  console.error('Release-readiness validation failed:');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log(`Release metadata/configuration checks passed for ${appJson.version}.`);
+console.log(`Resolved decisions: ${releaseStatus.resolved.length}`);
+console.log(`Manual release blockers: ${releaseStatus.blockers.length}`);
+releaseStatus.blockers.forEach(({ gate, id, owner }) =>
+  console.log(`- [${gate}] ${id} (${owner})`));
+
+if (process.argv.includes('--strict') && releaseStatus.blockers.length > 0) {
+  console.error('Strict release gate remains closed until every recorded blocker is resolved.');
+  process.exit(2);
+}

--- a/apps/mobile/src/app/ballot/[key]/index.tsx
+++ b/apps/mobile/src/app/ballot/[key]/index.tsx
@@ -1,6 +1,7 @@
 import { createLegacyApiClient } from '@/api/client';
 import { LegacyApiError, type BallotDetail, type Candidate } from '@/api/legacy-api';
 import { BallotShareButton } from '@/components/ballot-share-button';
+import { BallotReportLink } from '@/components/ballot-report-link';
 import { CandidateRanking } from '@/components/candidate-ranking';
 import { ElectionResults } from '@/components/election-results';
 import { GroupQuestions } from '@/components/group-questions';
@@ -155,6 +156,7 @@ export default function BallotScreen() {
             />
           </>
         ) : null}
+        <BallotReportLink ballotKey={ballot.key} />
       </View>
     </ScrollView>
   );

--- a/apps/mobile/src/app/create.tsx
+++ b/apps/mobile/src/app/create.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
+  Linking,
   Platform,
   Pressable,
   ScrollView,
@@ -16,7 +17,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { V2ApiClient, V2ApiError, type CreatedBallot } from '@/api/v2-api';
 import { BallotShareButton } from '@/components/ballot-share-button';
+import { TermsAcceptance } from '@/components/terms-acceptance';
 import { getApiBaseUrl } from '@/config/api';
+import { TERMS_OF_SERVICE_URL } from '@/config/service-links';
 import { validateGuestBallot, type GuestBallotFieldErrors } from '@/features/guest-ballot';
 import { saveBallotManagementToken } from '@/utils/ballot-management-token-store';
 
@@ -35,6 +38,7 @@ export default function CreateBallotScreen() {
   const [message, setMessage] = useState('');
   const [createdBallot, setCreatedBallot] = useState<CreatedBallotSummary | null>(null);
   const [pendingManagementToken, setPendingManagementToken] = useState<string | null>(null);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
 
   const updateCandidate = (index: number, value: string) => {
     setCandidates((current) => current.map((candidate, candidateIndex) =>
@@ -68,6 +72,12 @@ export default function CreateBallotScreen() {
   };
 
   const createBallot = async () => {
+    if (!acceptedTerms) {
+      setMessage('Accept the ballot content rules before creating a ballot.');
+      setSubmissionState('error');
+      return;
+    }
+
     const validation = validateGuestBallot(name, candidates);
     if (!validation.ok) {
       setFieldErrors(validation.errors);
@@ -111,6 +121,15 @@ export default function CreateBallotScreen() {
       } else {
         setMessage('The ballot could not be created. Try again.');
       }
+      setSubmissionState('error');
+    }
+  };
+
+  const openTerms = async () => {
+    try {
+      await Linking.openURL(TERMS_OF_SERVICE_URL);
+    } catch {
+      setMessage('The Terms of Use could not be opened. Visit rankedchoices.com before continuing.');
       setSubmissionState('error');
     }
   };
@@ -265,6 +284,13 @@ export default function CreateBallotScreen() {
                 <Text style={styles.secondaryButtonText}>Add candidate</Text>
               </Pressable>
             ) : null}
+
+            <TermsAcceptance
+              accepted={acceptedTerms}
+              disabled={submitting}
+              onChange={setAcceptedTerms}
+              onOpenTerms={() => void openTerms()}
+            />
 
             {message ? (
               <Text accessibilityLiveRegion="assertive" style={styles.error}>{message}</Text>

--- a/apps/mobile/src/components/ballot-report-link.test.tsx
+++ b/apps/mobile/src/components/ballot-report-link.test.tsx
@@ -1,0 +1,13 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { BallotReportLink } from './ballot-report-link';
+
+describe('BallotReportLink', () => {
+  it('provides an accessible content-reporting mechanism', () => {
+    const html = renderToStaticMarkup(<BallotReportLink ballotKey="garden" />);
+
+    expect(html).toContain('Report this ballot');
+    expect(html).toContain('role="link"');
+  });
+});

--- a/apps/mobile/src/components/ballot-report-link.tsx
+++ b/apps/mobile/src/components/ballot-report-link.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { createBallotReportUrl, SUPPORT_EMAIL } from '@/config/service-links';
+
+type BallotReportLinkProps = {
+  ballotKey: string;
+};
+
+export function BallotReportLink({ ballotKey }: BallotReportLinkProps) {
+  const [error, setError] = useState('');
+
+  const report = async () => {
+    setError('');
+    try {
+      await Linking.openURL(createBallotReportUrl(ballotKey));
+    } catch {
+      setError(`Email ${SUPPORT_EMAIL} and include shortcode ${ballotKey}.`);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        accessibilityHint="Opens an email with this ballot shortcode so you can report objectionable or abusive content"
+        accessibilityRole="link"
+        onPress={() => void report()}
+        style={({ pressed }) => [styles.link, pressed && styles.pressed]}>
+        <Text style={styles.linkText}>Report this ballot</Text>
+      </Pressable>
+      {error ? (
+        <Text accessibilityLiveRegion="assertive" style={styles.error}>
+          {error}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', marginTop: 18 },
+  link: { paddingHorizontal: 12, paddingVertical: 8 },
+  linkText: { color: '#81261f', fontSize: 14, textDecorationLine: 'underline' },
+  error: { color: '#81261f', fontSize: 13, lineHeight: 19, marginTop: 6, textAlign: 'center' },
+  pressed: { opacity: 0.72 },
+});

--- a/apps/mobile/src/components/terms-acceptance.test.tsx
+++ b/apps/mobile/src/components/terms-acceptance.test.tsx
@@ -1,0 +1,33 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { TermsAcceptance } from './terms-acceptance';
+
+describe('TermsAcceptance', () => {
+  it('describes the content rules and exposes checkbox state', () => {
+    let nextAccepted: boolean | undefined;
+    const element = TermsAcceptance({
+      accepted: true,
+      onChange: (accepted) => { nextAccepted = accepted; },
+      onOpenTerms: () => undefined,
+    });
+    const html = renderToStaticMarkup(
+      <TermsAcceptance
+        accepted
+        onChange={() => undefined}
+        onOpenTerms={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('role="checkbox"');
+    expect(html).toContain('rights-infringing ballot content');
+    expect(html).toContain('Read the Terms of Use');
+    expect(html).toContain('role="link"');
+    const checkbox = Array.isArray(element.props.children)
+      ? element.props.children[0]
+      : element.props.children;
+    expect(checkbox.props.accessibilityState).toEqual({ checked: true, disabled: false });
+    checkbox.props.onPress();
+    expect(nextAccepted).toBe(false);
+  });
+});

--- a/apps/mobile/src/components/terms-acceptance.tsx
+++ b/apps/mobile/src/components/terms-acceptance.tsx
@@ -1,0 +1,65 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+type TermsAcceptanceProps = {
+  accepted: boolean;
+  disabled?: boolean;
+  onChange: (accepted: boolean) => void;
+  onOpenTerms: () => void;
+};
+
+export function TermsAcceptance({
+  accepted,
+  disabled = false,
+  onChange,
+  onOpenTerms,
+}: TermsAcceptanceProps) {
+  return (
+    <View style={styles.container}>
+      <Pressable
+        accessibilityLabel="Accept the ballot content rules"
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: accepted, disabled }}
+        disabled={disabled}
+        onPress={() => onChange(!accepted)}
+        style={({ pressed }) => [styles.acceptRow, pressed && styles.pressed]}>
+        <View style={[styles.checkbox, accepted && styles.checkboxAccepted]}>
+          {accepted ? <Text style={styles.checkmark}>✓</Text> : null}
+        </View>
+        <Text style={styles.acceptText}>
+          I agree not to create unlawful, abusive, hateful, sexually explicit, deceptive, or
+          rights-infringing ballot content.
+        </Text>
+      </Pressable>
+      <Pressable
+        accessibilityHint="Opens the Ranked Choices Terms of Use"
+        accessibilityRole="link"
+        disabled={disabled}
+        onPress={onOpenTerms}
+        style={({ pressed }) => [styles.termsLink, pressed && styles.pressed]}>
+        <Text style={styles.termsLinkText}>Read the Terms of Use</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { marginTop: 24 },
+  acceptRow: { alignItems: 'flex-start', flexDirection: 'row' },
+  checkbox: {
+    alignItems: 'center',
+    borderColor: '#71879a',
+    borderRadius: 5,
+    borderWidth: 2,
+    height: 24,
+    justifyContent: 'center',
+    marginRight: 11,
+    marginTop: 1,
+    width: 24,
+  },
+  checkboxAccepted: { backgroundColor: '#146c43', borderColor: '#146c43' },
+  checkmark: { color: '#ffffff', fontSize: 16, fontWeight: '900', lineHeight: 19 },
+  acceptText: { color: '#40556b', flex: 1, fontSize: 14, lineHeight: 21 },
+  termsLink: { alignSelf: 'flex-start', marginLeft: 35, marginTop: 7, paddingVertical: 4 },
+  termsLinkText: { color: '#075eb5', fontSize: 14, textDecorationLine: 'underline' },
+  pressed: { opacity: 0.72 },
+});

--- a/apps/mobile/src/config/service-links.test.ts
+++ b/apps/mobile/src/config/service-links.test.ts
@@ -6,6 +6,7 @@ import {
   SUPPORT_EMAIL,
   SUPPORT_URL,
   TERMS_OF_SERVICE_URL,
+  createBallotReportUrl,
 } from './service-links';
 
 describe('service links', () => {
@@ -30,5 +31,16 @@ describe('service links', () => {
     expect(SUPPORT_URL).toBe(
       `mailto:${SUPPORT_EMAIL}?subject=Ranked%20Choices%20support`,
     );
+  });
+
+  it('builds a report email containing only the public ballot reference', () => {
+    const reportUrl = createBallotReportUrl(' garden/2026 ');
+
+    expect(reportUrl).toContain(`mailto:${SUPPORT_EMAIL}`);
+    expect(decodeURIComponent(reportUrl)).toContain('Report Ranked Choices ballot garden/2026');
+    expect(decodeURIComponent(reportUrl)).toContain(
+      'https://rankedchoices.com/ballot/garden%2F2026',
+    );
+    expect(reportUrl).not.toContain('managementToken');
   });
 });

--- a/apps/mobile/src/config/service-links.ts
+++ b/apps/mobile/src/config/service-links.ts
@@ -1,5 +1,17 @@
+import { canonicalBallotUrl } from '@/features/ballot-sharing';
+
 export const PRIVACY_POLICY_URL = 'https://rankedchoices.com/privacy-policy.html';
 export const TERMS_OF_SERVICE_URL = 'https://rankedchoices.com/terms-of-service.html';
 export const SOURCE_CODE_URL = 'https://github.com/DavidMoritz/rcv';
 export const SUPPORT_EMAIL = 'davidmoritz@gmail.com';
 export const SUPPORT_URL = `mailto:${SUPPORT_EMAIL}?subject=Ranked%20Choices%20support`;
+
+export function createBallotReportUrl(ballotKey: string): string {
+  const normalizedKey = ballotKey.trim();
+  const subject = encodeURIComponent(`Report Ranked Choices ballot ${normalizedKey}`);
+  const body = encodeURIComponent(
+    `Ballot shortcode: ${normalizedKey}\nBallot link: ${canonicalBallotUrl(normalizedKey)}\n\nDescribe the objectionable or abusive content:\n`,
+  );
+
+  return `mailto:${SUPPORT_EMAIL}?subject=${subject}&body=${body}`;
+}

--- a/apps/mobile/store/metadata/en-US.json
+++ b/apps/mobile/store/metadata/en-US.json
@@ -1,0 +1,58 @@
+{
+  "locale": "en-US",
+  "shared": {
+    "appName": "Ranked Choices",
+    "price": "Free",
+    "availability": ["United States"],
+    "primaryCategory": "Utilities",
+    "secondaryCategory": "Productivity"
+  },
+  "apple": {
+    "subtitle": "Rank choices. See results.",
+    "promotionalText": "Create a simple ballot, share its link, rank choices, and follow transparent round-by-round results without creating an account.",
+    "description": "Ranked Choices helps groups make decisions with ranked-choice voting.\n\nOpen a ballot from a shared link or shortcode, arrange the choices in your order of preference, and submit your vote. When results are available, see the winner and round-by-round totals calculated directly in the app.\n\nYou can also create a basic ballot with a name and at least two choices, then share its canonical RankedChoices.com link. Advanced configuration and ballot management remain available on the website.\n\nSupported voting experiences include anonymous ballots, organizer-provided voter codes, multiple winners, and optional group questions. The app provides clear states when a ballot is closed, unavailable, or requires a feature that is not yet supported natively.\n\nRanked Choices does not contain advertising or product analytics. The source code is public, and privacy, support, and reporting links are available inside the app.\n\nRanked Choices is intended for informal and community decision-making. It is not an official election-administration system and should not be relied on for critical or legally binding voting.",
+    "keywords": "ballot,poll,voting,ranked choice,instant runoff,STV,election,group decision",
+    "supportUrl": "https://rankedchoices.com/about",
+    "marketingUrl": "https://rankedchoices.com/",
+    "privacyPolicyUrl": "https://rankedchoices.com/privacy-policy.html"
+  },
+  "googlePlay": {
+    "shortDescription": "Create ballots, rank choices, vote by code, and see round-by-round results.",
+    "fullDescription": "Ranked Choices helps groups make decisions with ranked-choice voting.\n\nOpen a ballot from a shared link or shortcode, arrange the choices in your order of preference, and submit your vote. When results are available, see the winner and round-by-round totals calculated directly in the app.\n\nCreate a basic ballot with a name and at least two choices, then share its canonical RankedChoices.com link. Advanced configuration and ballot management remain available on the website.\n\nThe app supports anonymous ballots, organizer-provided voter codes, multiple winners, and optional group questions. Clear messages explain when a ballot is closed, unavailable, or requires a feature that is not yet supported natively.\n\nThere are no ads or product analytics. Privacy, support, Terms of Use, and content-reporting links are available from within the app. Ranked Choices is open source.\n\nRanked Choices is intended for informal and community decision-making. It is not an official election-administration system and should not be relied on for critical or legally binding voting.",
+    "supportEmail": "davidmoritz@gmail.com",
+    "website": "https://rankedchoices.com/",
+    "privacyPolicyUrl": "https://rankedchoices.com/privacy-policy.html"
+  },
+  "screenshots": [
+    {
+      "order": 1,
+      "screen": "home",
+      "caption": "Open any shared ballot",
+      "altText": "Ranked Choices home screen with a field for entering a ballot shortcode."
+    },
+    {
+      "order": 2,
+      "screen": "ranking",
+      "caption": "Rank choices your way",
+      "altText": "A sample community garden ballot with accessible controls for reordering choices."
+    },
+    {
+      "order": 3,
+      "screen": "secure-vote",
+      "caption": "Support voter codes and group questions",
+      "altText": "A sample ballot requesting an organizer-provided voter code and a group answer."
+    },
+    {
+      "order": 4,
+      "screen": "results",
+      "caption": "Understand every round",
+      "altText": "Round-by-round ranked-choice results for a fictional community garden ballot."
+    },
+    {
+      "order": 5,
+      "screen": "create",
+      "caption": "Create and share a basic ballot",
+      "altText": "Basic ballot creation form with a ballot name, candidate fields, and content rules."
+    }
+  ]
+}

--- a/apps/mobile/store/release-status.json
+++ b/apps/mobile/store/release-status.json
@@ -1,0 +1,88 @@
+{
+  "schemaVersion": 1,
+  "lastReviewed": "2026-09-11",
+  "resolved": [
+    {
+      "id": "store-owner",
+      "summary": "David Moritz owns and controls the Apple and Google store listings.",
+      "source": "Maintainer email received 2026-09-09"
+    },
+    {
+      "id": "production-identifiers",
+      "summary": "The production Apple bundle ID and Android package are com.rankedchoices.app.",
+      "source": "Maintainer guidance incorporated in the Expo migration RFC"
+    },
+    {
+      "id": "ios-simulator-smoke",
+      "summary": "The guest create, encrypted credential storage, vote, and results flow passed on an iOS simulator.",
+      "source": "Local verification completed 2026-09-07"
+    },
+    {
+      "id": "ios-development-build",
+      "summary": "The regenerated development workspace compiled without signing and the installed app loaded through Metro on an iPhone 17 Pro simulator; the content-rules control was verified through accessibility state.",
+      "source": "Local verification completed 2026-09-11"
+    }
+  ],
+  "blockers": [
+    {
+      "id": "store-access-and-signing",
+      "owner": "David",
+      "summary": "Confirm the Apple account type/signing workflow and invite the release contributor to App Store Connect and Play Console.",
+      "gate": "signed-build"
+    },
+    {
+      "id": "eas-ownership",
+      "owner": "David",
+      "summary": "Create or select the durable Expo organization/project and grant the release contributor access.",
+      "gate": "signed-build"
+    },
+    {
+      "id": "branded-assets",
+      "owner": "David",
+      "summary": "Approve production app icons and a Play feature graphic; the current Expo icon is a placeholder.",
+      "gate": "store-record"
+    },
+    {
+      "id": "production-backend",
+      "owner": "David",
+      "summary": "Back up and migrate production, deploy the v2 APIs, and complete production smoke verification.",
+      "gate": "beta"
+    },
+    {
+      "id": "privacy-metadata",
+      "owner": "David",
+      "summary": "Reconcile and approve the privacy policy, App Privacy answers, and Play Data safety answers against production operations.",
+      "gate": "store-review"
+    },
+    {
+      "id": "moderation-operations",
+      "owner": "David",
+      "summary": "Approve a monitored reporting channel, response target, enforcement process, and backup coverage for user-generated ballot content.",
+      "gate": "store-review"
+    },
+    {
+      "id": "verified-link-identities",
+      "owner": "David",
+      "summary": "Provide the final Apple Team ID and Google Play app-signing SHA-256 fingerprint, then publish and verify association files.",
+      "gate": "beta"
+    },
+    {
+      "id": "staging-environment",
+      "owner": "David",
+      "summary": "Provision staging.rankedchoices.com and point the staging EAS profile to its isolated database and API.",
+      "gate": "beta"
+    },
+    {
+      "id": "beta-verification",
+      "owner": "Release team",
+      "summary": "Complete signed physical-device, TestFlight, and Play internal-testing verification with disposable data.",
+      "gate": "store-review"
+    },
+    {
+      "id": "release-approval",
+      "owner": "David",
+      "summary": "Approve the final build numbers, store copy/assets, review notes, availability, and manual or phased release settings.",
+      "gate": "public-release"
+    }
+  ]
+}

--- a/docs/expo-migration-rfc.md
+++ b/docs/expo-migration-rfc.md
@@ -2,10 +2,10 @@
 
 - Status: Accepted; Phases 0 and 1 implemented; Phase 2 in progress
 - Date: 2026-08-08
-- Last updated: 2026-09-07
+- Last updated: 2026-09-11
 - Proposer: Emmanuel Jones
 - Decision horizon: architecture and first product milestone
-- Maintainer guidance received: 2026-08-30 and 2026-09-05
+- Maintainer guidance received: 2026-08-30, 2026-09-05, and 2026-09-09
 
 ## Summary
 
@@ -334,6 +334,34 @@ token, then revoke or rotate the guest credential. Advanced owner workflows
 remain deferred until their endpoints enforce the same server-verified
 authorization boundary.
 
+### 14. Keep the store records under maintainer control
+
+David Moritz will own and control the App Store Connect and Google Play
+Console listings. Release contributors should receive least-privilege access
+to prepare and upload builds; account agreements, recovery, and final release
+control remain with the maintainer. The Expo project and signing identities
+must likewise live under durable maintainer-controlled accounts rather than a
+temporary contributor account.
+
+This ownership decision does not itself authorize a release. Production API
+deployment, signed beta verification, metadata and privacy review, and final
+maintainer approval remain separate gates.
+
+### 15. Treat ballot text as user-generated content
+
+Ballot names and candidate or choice names are user-generated content even
+though the app has no public ballot directory, feed, messaging, or
+recommendations. Native ballot creation therefore requires explicit
+acceptance of content rules, every loaded ballot provides a reporting action,
+and the Terms prohibit abusive, unlawful, deceptive, privacy-violating, and
+rights-infringing content.
+
+These UI controls require a corresponding moderation operation before store
+submission: a monitored channel, response target, evidence-minimizing review,
+ballot-removal capability, escalation rules, and backup coverage. If store
+review does not accept an email-composer report as sufficiently in-app, a
+first-party reporting endpoint and moderation queue must ship before release.
+
 ## Target architecture
 
 ```text
@@ -521,14 +549,19 @@ complete. Phase 2's guest create -> store credential -> open ballot -> vote ->
 results path has now passed on both Android and an iOS simulator against the
 real local PHP/MySQL backend. Xcode MCP also completed a clean native iOS build.
 
-Production distribution follows `docs/mobile-release-checklist.md`. Store
-account ownership must be settled before registering or uploading the
-production identifiers. The app-side production/staging link declarations and
+Production distribution follows `docs/mobile-release-checklist.md`. David
+Moritz has confirmed that he will own and control both store listings. The
+Apple account type, team access, Expo ownership, and signing workflow still
+must be confirmed before registering or uploading the production identifiers.
+The app-side production/staging link declarations and
 non-deployable association templates may be reviewed in advance, but the
 server files require the final Apple Team ID and Google Play app-signing
-fingerprint. The privacy policy, support path, production API deployment,
-association files, signed physical-device testing, and TestFlight/Play internal
-testing are release gates.
+fingerprint. The privacy policy, moderation operation, support path,
+production API deployment, association files, signed physical-device testing,
+and TestFlight/Play internal testing are release gates. Draft store copy,
+privacy answers, screenshot scenes, and reviewer notes live in
+`docs/mobile-store-submission.md`; machine-readable status is checked from
+`apps/mobile/store/`.
 
 Revisit this RFC during store-account setup and again before Phase 3
 authentication work.

--- a/docs/mobile-release-checklist.md
+++ b/docs/mobile-release-checklist.md
@@ -7,8 +7,8 @@ or store API credentials in the repository.
 
 ## 1. Ownership and access
 
-- [ ] The maintainer has recorded which durable legal person or entity owns
-  the App Store Connect and Google Play Console listings.
+- [x] David Moritz confirmed on September 9, 2026 that he will own and retain
+  control of the App Store Connect and Google Play Console listings.
 - [ ] The selected accounts, rather than a temporary contributor account, own
   the production identifiers and signing identities.
 - [ ] Release contributors have least-privilege App Manager/Developer access;
@@ -79,6 +79,9 @@ be cached by the device.
 
 ## 5. Privacy, support, and store metadata
 
+- [ ] The maintainer reviews the draft store copy, screenshot plan, privacy
+  matrix, and review notes in `docs/mobile-store-submission.md`; copyable
+  metadata remains versioned in `apps/mobile/store/metadata/en-US.json`.
 - [ ] The maintainer reviews `src/privacy-policy.html` against actual hosting,
   log, backup, analytics, Sentry, and deletion practices and obtains legal
   review if appropriate.
@@ -92,16 +95,34 @@ be cached by the device.
 - [ ] Screenshots contain only disposable ballots and no personal, voter-code,
   management-token, production-account, or private test information.
 - [ ] Export-compliance answers are reviewed for HTTPS and SecureStore usage.
+- [ ] The current Expo placeholder icon is replaced with approved production
+  icon/adaptive-icon assets, and an approved Play feature graphic is exported.
+
+## 6. User-generated content and moderation
+
+- [x] Native ballot creation requires explicit acceptance of content rules,
+  and the Terms prohibit abusive and rights-infringing ballot content.
+- [x] Every native ballot exposes an accessible report action that includes
+  only its public shortcode and canonical link.
+- [ ] The maintainer approves who monitors reports, the response target,
+  evidence-minimization rules, enforcement steps, and backup coverage.
+- [ ] A release rehearsal confirms a report reaches the monitored channel and
+  a moderator can locate and remove a disposable violating ballot.
+- [ ] Store review confirms whether the mail-composer flow is sufficient; if
+  not, ship a first-party report API and moderation queue before release.
 
 Safety check: have one reviewer trace every privacy disclosure back to code or
 an operating practice and a second reviewer compare the final store forms with
-the published policy.
+the published policy. Moderation testing must use fictional content and must
+never place voter codes or management credentials in a report.
 
-## 6. Automated and device verification
+## 7. Automated and device verification
 
 - [ ] Root Vitest, PHPUnit, Playwright, live MySQL contracts, and production
   Vite build pass from the release commit.
 - [ ] Mobile Vitest, TypeScript, Expo lint, and static export pass.
+- [ ] `npm run validate:release` passes and
+  `npm run validate:release:strict` reports no unresolved blockers.
 - [ ] Xcode builds the production scheme without errors or unresolved signing
   warnings; Android produces a signed release bundle.
 - [ ] Android device E2E covers incoming link -> rank -> submit -> results,
@@ -115,7 +136,7 @@ Safety check: use disposable records and record the shortcode or database ID
 before each mutation so cleanup targets only test data. Never capture raw
 management tokens in screenshots, logs, CI artifacts, or bug reports.
 
-## 7. TestFlight and Play internal testing
+## 8. TestFlight and Play internal testing
 
 - [ ] Upload signed release candidates and resolve all processing, privacy,
   compliance, and symbol warnings.
@@ -132,7 +153,7 @@ management tokens in screenshots, logs, CI artifacts, or bug reports.
 Safety check: upload does not authorize release. Keep manual release control
 for version 1.0 so approval cannot publish an unreviewed backend/build pairing.
 
-## 8. Public release and rollback
+## 9. Public release and rollback
 
 - [ ] Re-run external API, policy/support URL, and association-file checks
   immediately before submission and release.
@@ -155,5 +176,7 @@ for diagnosis. Do not drop additive schema during an active rollback.
 - [App Store Connect accounts and roles](https://developer.apple.com/help/app-store-connect/manage-your-team/overview-of-accounts-and-roles/)
 - [TestFlight overview](https://developer.apple.com/help/app-store-connect/test-a-beta-version/testflight-overview)
 - [App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [Google Play user-generated-content policy](https://support.google.com/googleplay/android-developer/answer/9876937)
+- [Google Play Data safety guidance](https://support.google.com/googleplay/android-developer/answer/10787469)
 - [Apple app-transfer criteria](https://developer.apple.com/help/app-store-connect/transfer-an-app/app-transfer-criteria)
 - [Expo app-store submission](https://docs.expo.dev/submit/ios/)

--- a/docs/mobile-store-submission.md
+++ b/docs/mobile-store-submission.md
@@ -1,0 +1,219 @@
+# Mobile store submission draft
+
+This is the working source for the first iOS and Android store records. The
+copyable English (United States) metadata lives in
+apps/mobile/store/metadata/en-US.json and is checked by running
+npm run validate:release from apps/mobile.
+
+Nothing in this document authorizes submission or release. David Moritz owns
+the store records and retains final production-release control.
+
+## Resolved setup
+
+- Publisher/store owner: David Moritz, per his September 9, 2026 response.
+- Public app name: Ranked Choices.
+- Production identifier on both platforms: com.rankedchoices.app.
+- Initial version: 1.0.0; iOS build 1; Android version code 1.
+- Price: free, with no in-app purchases, subscriptions, advertising, or
+  product analytics.
+- Proposed availability: United States only, matching the current Terms of
+  Use. Expanding availability requires Terms and legal review.
+- Proposed categories: Utilities primary; Productivity secondary.
+- Support URL: https://rankedchoices.com/about.
+- Marketing URL: https://rankedchoices.com/.
+- Privacy URL: https://rankedchoices.com/privacy-policy.html.
+
+## Copy review
+
+The metadata deliberately avoids claims that the app is suitable for official,
+critical, or legally binding elections. It describes only features present in
+the first native release: shortcode/link lookup, accessible ranking, vote
+submission, voter codes, group questions, local round results, link sharing,
+and basic guest ballot creation. Accounts and advanced management remain on
+the website.
+
+Before copying it into either console:
+
+1. David approves the categories, United States-only availability, developer
+   name, copyright line, support email, and all descriptive copy.
+2. The production API and privacy page are live.
+3. The exact submitted build is checked against the copy. Remove any feature
+   not enabled in that build.
+4. Re-run npm run validate:release; do not shorten copy ad hoc in a store
+   console without updating the repository source.
+
+The copyright line remains intentionally undecided because it must name the
+person or entity that owns the exclusive rights, not merely the account used
+to upload the app.
+
+## App Review notes
+
+Use this as the basis for the private review notes, updating URLs and test data
+immediately before submission:
+
+> Ranked Choices is a ranked-choice ballot client for RankedChoices.com. No
+> account is required. A reviewer can select Create a basic ballot, accept the
+> content rules, enter a fictional ballot name and at least two choices, and
+> open the resulting ballot. The one-time management credential is stored in
+> encrypted device storage and is never displayed.
+>
+> To test voting, rank the choices with the Move up, Move down, and Remove
+> controls, submit the vote, and view the local round-by-round results. The app
+> also opens a ballot from its public shortcode or canonical HTTPS link.
+>
+> Advanced ballot configuration and account-based management remain on the
+> website. Name-required ballots are explicitly unsupported in this release.
+> Ranked Choices is intended for informal decision-making, not official or
+> legally binding elections.
+>
+> Ballot names and choices are user-generated but are not publicly browsable
+> or recommended; a user must receive a link or shortcode. Creators accept the
+> content rules before creating a native ballot. Every loaded ballot includes
+> a Report this ballot action, and support contact information and Terms of Use
+> are available in the app.
+
+If review needs a secure-code or group-question flow, create a disposable
+review ballot shortly before submission and place its shortcode and code only
+in the private store review fields. Never commit or place them in screenshots.
+Delete that ballot after review.
+
+## User-generated content and moderation
+
+Ballot names and candidate/choice names are user-generated content. The first
+release reduces exposure by providing no public directory, search, social
+feed, messaging, or recommendation system. Access requires a shared link or
+shortcode.
+
+The app requires explicit acceptance of the content rules before native ballot
+creation and gives every ballot an accessible reporting action. The Terms
+prohibit unlawful, abusive, hateful, sexually explicit, exploitative,
+deceptive, privacy-violating, and rights-infringing content.
+
+These product controls are not sufficient without an operating process.
+Before store submission David must approve and document:
+
+- who monitors davidmoritz@gmail.com for content reports;
+- a reasonable target for acknowledging and investigating a report;
+- how the responder validates the shortcode and preserves minimal evidence;
+- how violating ballots are removed with the existing admin tools;
+- when an account, guest credential, device, or network source is restricted;
+- how reporters are told the outcome when appropriate; and
+- who provides coverage when the primary moderator is unavailable.
+
+The stores make the final policy determination. If an email-composer reporting
+flow is not accepted as sufficiently in-app, replace it with a first-party
+report API and moderation queue before release.
+
+## Screenshot plan
+
+Capture five truthful portrait screens in the order recorded in the metadata:
+home, ranking, secure/group voting, results, and basic creation. Use the
+fictional ballot “Community Garden Project” with choices such as “Native flower
+beds,” “Shade trees,” “Picnic tables,” and “Compost station.” Do not use real
+people, political candidates, private groups, production accounts, voter
+codes, or management credentials.
+
+For Apple, capture a final release candidate at one accepted 6.9-inch portrait
+size. App Store Connect currently accepts 1260×2736, 1290×2796, or 1320×2868
+pixels and permits one to ten screenshots. For Google Play, prepare at least
+four 9:16 phone screenshots at 1080×1920 or higher; Google permits up to eight
+per device type and requires at least two overall.
+
+Capture requirements:
+
+- use the actual release UI without Expo development controls or debug labels;
+- set a neutral time, full signal/Wi-Fi/battery indicators, and no
+  notifications;
+- keep the first three images focused on real app UI;
+- use no device frames, store badges, rankings, testimonials, pricing claims,
+  or time-sensitive copy;
+- keep optional captions small and consistent, and localize any overlay text;
+- export JPEG or PNG without transparency; and
+- enter the repository alt text in Play Console, adjusting it if the final
+  frame differs.
+
+Do not produce final screenshots until the branded app icon, production-like
+backend, exact release build, and moderation UI are approved. Simulator
+captures before that point are useful only for layout rehearsal.
+
+## Draft privacy and data-safety answers
+
+This matrix is conservative and must be reconciled with the exact binary,
+backend operations, hosting logs, and store form wording before it is
+published.
+
+| Data or behavior | Apple draft | Google Play draft | Handling |
+|---|---|---|---|
+| Ballot names and choices | Other User Content; app functionality | Other user-generated content; collected; app functionality | Supplied only when a user creates a ballot |
+| Rankings and group answers | Other User Content; app functionality | Other user-generated content; collected; app functionality | Submitted to the Ranked Choices API |
+| Organizer voter code | Other User Content or User ID; app functionality/fraud prevention | Other user-generated content; collected; app functionality/fraud prevention | Required only for a secure ballot |
+| Submitted-vote IP address | Confirm the closest identifier/other-data category; app functionality/security | Device or other IDs; collected; app functionality/fraud prevention | Stored by the vote API; not used for advertising |
+| Random installation ID | Device ID; app functionality/fraud prevention; linked to the vote, not tracking | Device or other IDs; collected; optional; app functionality/fraud prevention | Sent only when one-device-one-vote is enabled |
+| Idempotency request ID | Usually not user data; confirm in final review | Usually not user data; confirm in final review | Random request-scoped identifier preventing duplicate votes |
+| Guest management credential | Not collected from the user | Not collected from the user | Server creates it; encrypted on device; server retains only a digest |
+| Support email/content | Contact Info and Other User Content if the store treats mail launched from the app as collection | Email address and Other user-generated content if applicable | User chooses whether to send through their mail provider |
+| Sentry crash diagnostics | Omit when disabled; Crash Data/Diagnostics if enabled | Crash logs/Diagnostics if enabled | Disabled unless the exact build opts in |
+
+Provisional global answers:
+
+- Data is encrypted in transit in production.
+- No data is used for cross-app tracking or advertising.
+- No data is sold.
+- The app has no account sign-in in version 1.0.
+- Deletion requests are available through the privacy-policy contact; the
+  maintainer must verify the actual deletion and backup-retention process.
+- Infrastructure processors are service providers, but David must confirm
+  contracts and actual practices before answering whether either store treats
+  any transfer as sharing.
+- Do not declare approximate location unless the service actually infers it
+  from IP addresses. Confirm that hosting, security, and analytics systems do
+  not do so.
+- If Sentry is enabled, redo the matrix against the final SDK configuration
+  and a captured sanitized event before submission.
+
+## Graphic assets
+
+The current mobile icon is Expo's default placeholder and must not be
+submitted. Existing Ranked Choices website artwork is available, but the
+maintainer must approve a square, legible adaptation before it replaces the
+placeholder.
+
+Required production assets include:
+
+- a 1024×1024 iOS icon with no unintended transparency;
+- a 512×512 Play Store icon, maximum 1024 KB;
+- Android adaptive foreground, background, and monochrome layers; and
+- a 1024×500 Play feature graphic in JPEG or 24-bit PNG without alpha.
+
+The Play feature graphic should extend the existing brand without duplicating
+the icon, device imagery, or store badges. All source and export files should
+be reviewed at small display sizes before submission.
+
+## Remaining confirmations
+
+The following are intentionally not guessed:
+
+- Apple account type and signing workflow;
+- David-owned Expo organization name and membership;
+- exact public developer/seller name and copyright owner;
+- final availability and category selections;
+- branded icon/feature-graphic approval;
+- production moderation owner and response process;
+- App Store privacy and Play Data safety interpretations noted above;
+- export-compliance answer for the final binary; and
+- final manual/phased release settings.
+
+Account invitations, Team ID, Play signing fingerprint, production deployment,
+and association-file publication remain governed by
+docs/mobile-release-checklist.md.
+
+## Store references
+
+- [Apple metadata fields and limits](https://developer.apple.com/help/app-store-connect/reference/app-information/platform-version-information/)
+- [Apple screenshot specifications](https://developer.apple.com/help/app-store-connect/reference/app-information/screenshot-specifications/)
+- [Apple App Review Guidelines](https://developer.apple.com/app-store/review/guidelines/)
+- [Apple App Privacy details](https://developer.apple.com/app-store/app-privacy-details/)
+- [Google Play store-listing requirements](https://support.google.com/googleplay/android-developer/answer/9859152)
+- [Google Play graphic-asset requirements](https://support.google.com/googleplay/android-developer/answer/9866151)
+- [Google Play user-generated-content policy](https://support.google.com/googleplay/android-developer/answer/9876937)
+- [Google Play Data safety guidance](https://support.google.com/googleplay/android-developer/answer/10787469)

--- a/src/terms-of-service.html
+++ b/src/terms-of-service.html
@@ -61,13 +61,13 @@
 <body>
 <div class="container">
   <h1>TERMS OF USE</h1>
-  <p style="color:#888; font-size:13px; margin-bottom:4px;">Version 2.9.24</p>
+  <p style="color:#888; font-size:13px; margin-bottom:4px;">Version 2026.09.11</p>
   <p>See the <a href="https://rankedchoices.com/privacy-policy.html">Privacy Policy</a> for how the website and mobile apps handle information.</p>
-  <p>Thanks for stopping by! These Terms of Use set out the rules for your use of this app / access to this website. Before using rankedchoices.com, you're required to read and agreed to these Terms of Use.  Remember that just by using rankedchoices.com, you're automatically agreeing to all of these terms and conditions. </p>
+  <p>Thanks for stopping by! These Terms of Use set out the rules for using RankedChoices.com and the Ranked Choices mobile apps (collectively, the "Services"). Before using the Services, you are required to read and agree to these Terms of Use. By using the Services, you agree to these terms and conditions.</p>
   <h4>Basics:</h4>
   <ol>
-    <li>These terms and conditions of use ("Terms") govern your access to and use of rankedchoices.com, including any content, functionality, and services offered on or through rankedchoices.com or its subdomains (referred to collectively as the "Website"). By accessing, viewing, or using the Website or any of its tools, you are agreeing to be bound by these Terms. </li>
-    <li>If you don't agree with any term or condition outlined in these Terms, then you may not access the Website. </li>
+    <li>These terms and conditions of use ("Terms") govern your access to and use of the Services, including content and functionality offered through RankedChoices.com, its subdomains, and the Ranked Choices mobile apps. By accessing, viewing, or using the Services, you agree to be bound by these Terms.</li>
+    <li>If you don't agree with any term or condition outlined in these Terms, then you may not access the Services.</li>
     <li>We may change the Terms at any time in our sole discretion. All changes are effective immediately when posted, and apply to all access to and use of the Website thereafter. Your continued use of the Website following the posting of revised Terms means that you accept and agree to the changes. You're expected to check this page when you access the Website so you're aware of any changes, because they are binding on you. </li>
     <li>These Terms constitute the entire agreement between you and RankedChoices.com and replace all previous agreements under this title. </li>
     <li>The Website is offered and available to users who are at least 13 years old and in the United States. </li>
@@ -88,10 +88,12 @@
     <li>For the purpose of exploiting, harming, or attempting to exploit or harm minors in any way by exposing them to inappropriate content, asking for personally identifiable information, or otherwise.</li>
     <li>To transmit, or procure the sending of, any advertising or promotional material, including any "junk mail," "chain letter," "spam," or any other similar solicitation.</li>
     <li>To impersonate or attempt to impersonate someone else, or otherwise use the Website to engage in any act of deception.</li>
+    <li>To create or distribute content that is threatening, harassing, hateful, sexually explicit, exploitative, defamatory, or intended to bully or single out another person for abuse.</li>
+    <li>To publish another person's sensitive or private information without authorization, or content that infringes intellectual-property or other legal rights.</li>
     <li>In any manner that could disable, overburden, damage, or impair the site or interfere with any other party's use of the Website, including their ability to engage in real time activities through the Website.</li>
   </ol>
   <p>You also agree not to use any manual or automatic device or process to monitor or copy any of the material on the Website or for any other purpose not expressly authorized in the Terms, or attempt to gain unauthorized access to or to disruption of any part of the Website, or to otherwise interfere or attempt to interfere with the proper working of the Website. </p>
-  <p>We have the right (but no obligation) to screen, review, filter, change, reject, or remove any content or accounts from the Website at our sole discretion. <p>
+  <p>We have the right (but no obligation) to screen, review, filter, change, reject, or remove any content or accounts from the Website at our sole discretion.</p>
   <h4>User Content:</h4>
   <ol>
     <li>The Website may contain certain interactive features (collectively, "Interactive Services") that allow users to post, publish, or share with others (hereinafter, "post") content or materials (collectively, "User Content") on or through the Website.</li>
@@ -100,6 +102,12 @@
     <li>You represent, warrant, and agree that all of your User Content does and will comply with these Terms.</li>
     <li>You understand and agree that you are responsible for any User Content you submit or contribute, and you (not us), have full responsibility for such content, including its legality, reliability, accuracy, and appropriateness.</li>
     <li>We are not responsible or liable to any third party for the content or accuracy of any User Content posted by you or any other user of the Website.</li>
+  </ol>
+  <h4>Reporting and Enforcement:</h4>
+  <ol>
+    <li>If a ballot or other User Content appears to violate these Terms, use the in-app reporting link or email <a href="mailto:davidmoritz@gmail.com?subject=Report%20Ranked%20Choices%20content">davidmoritz@gmail.com</a>. Include the ballot shortcode or link and a description of the concern; do not include voter codes or management credentials.</li>
+    <li>We may investigate reports and remove content, disable access, or restrict accounts or credentials when reasonably necessary to enforce these Terms, protect users, or comply with law.</li>
+    <li>Submitting a deliberately false or abusive report is itself a misuse of the Services.</li>
   </ol>
   <h4>Reliance on Information Posted:</h4>
   <ol>


### PR DESCRIPTION
## Summary

- add versioned App Store and Google Play metadata, submission guidance, and a machine-checked release-blocker manifest
- add explicit ballot-content rule acceptance and an accessible per-ballot reporting action without exposing voter or management credentials
- update the Terms and Expo migration RFC for mobile distribution, user-generated content, and David-owned store records
- add release configuration validation to CI, including identifiers, API targets, link-association placeholders, metadata limits, and required safeguards

## Verification

- root npm test: 191 Vitest tests and 231 PHPUnit tests / 587 assertions passed
- root npm run build passed
- mobile npm test: 23 files / 72 tests passed
- mobile npm run typecheck passed
- mobile npm run lint passed
- mobile Expo web export passed
- pod install passed after regenerating the ignored iOS workspace
- unsigned RankedChoicesDev Xcode build for a generic iOS Simulator passed (123-target dependency graph)
- installed and launched on an iPhone 17 Pro simulator; the create screen and accessible content-rules checkbox were verified at runtime
- npm run validate:release passed and reports the 10 intentional manual gates
- npm run validate:release:strict intentionally exits 2 until those gates are resolved
- git diff --check passed

## Review notes

The Terms changes, store copy, privacy/data-safety draft, moderation process, categories, availability, and graphic assets all remain explicit maintainer approval gates. This PR does not authorize a store upload or release.
