### PR TITLE
fix: the admin in admin.php

### DIFF
--- a/src/api/admin.php
+++ b/src/api/admin.php
@@ -21,6 +21,17 @@ $action = $_GET['action'] ?? $_POST['action'] ?? '';
 $data = [];
 $errors = [];
 
+function auditLog($action, $details) {
+    $entry = [
+        'time' => date('c'),
+        'action' => $action,
+        'ip' => $_SERVER['REMOTE_ADDR'] ?? 'unknown',
+        'adminTokenHash' => isset($_SESSION['admin_token']) ? hash('sha256', $_SESSION['admin_token']) : null,
+        'details' => $details,
+    ];
+    error_log('ADMIN_AUDIT: ' . json_encode($entry));
+}
+
 // Validate admin token for all actions except login
 if ($action !== 'login') {
     $token = $_SERVER['HTTP_X_ADMIN_TOKEN'] ?? '';
@@ -181,6 +192,7 @@ switch ($action) {
             $stmt->execute([':id' => $ballotId]);
 
             $dbh->commit();
+            auditLog('delete-ballot', ['ballotId' => $ballotId]);
             $data['success'] = true;
         } catch (Exception $e) {
             $dbh->rollBack();
@@ -198,6 +210,7 @@ switch ($action) {
         $stmt = $dbh->prepare("DELETE FROM votes WHERE ballotId = :id");
         $stmt->execute([':id' => $ballotId]);
         $data['deletedCount'] = $stmt->rowCount();
+        auditLog('delete-votes', ['ballotId' => $ballotId, 'deletedCount' => $data['deletedCount']]);
         $data['success'] = true;
         break;
 
@@ -223,6 +236,7 @@ switch ($action) {
 
         $stmt = $dbh->prepare("UPDATE ballots SET createdBy = :owner WHERE id = :id");
         $stmt->execute([':owner' => $newOwnerId, ':id' => $ballotId]);
+        auditLog('transfer-ballot', ['ballotId' => $ballotId, 'newOwnerId' => $newOwnerId]);
         $data['success'] = true;
         break;
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/api/admin.php`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/api/admin.php:1` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The admin.php API handles sensitive administrative actions including deleting ballots (delete-ballot), deleting votes (delete-votes), transferring ballot ownership (transfer-ballot), and user management without implementing any audit logging. All administrative operations execute without creating an immutable record of who performed the action, when, and what was changed.

## Evidence

**Exploitation scenario**: A malicious administrator or attacker with compromised admin credentials performs destructive actions such as deleting ballots, clearing vote records, or transferring ballot ownership.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This API endpoint appears to be publicly accessible. This is a web application - XSS and injection vulnerabilities can affect end users.

## Changes
- `src/api/admin.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```php
<?php
use PHPUnit\Framework\TestCase;

class AdminAuditLoggingTest extends TestCase
{
    private string $adminFile = __DIR__ . '/../src/api/admin.php';

    /**
     * Invariant: All administrative actions MUST produce immutable audit records
     */
    public function testAdministrativeActionsRequireAuditLogging(): void
    {
        $this->assertFileExists($this->adminFile, 'Admin API file must exist');

        $content = file_get_contents($this->adminFile);
        
        // Check for audit logging patterns - must exist for delete/transfer actions
        $hasAuditLogging = preg_match('/audit|log.*action|write.*log|immutable.*record/i', $content);
        
        // Critical administrative actions that require audit trails
        $criticalActions = ['delete-ballot', 'delete-votes', 'transfer-ballot'];
        foreach ($criticalActions as $action) {
            $hasActionHandler = strpos($content, $action) !== false;
            if ($hasActionHandler) {
                $this->assertTrue(
                    (bool)$hasAuditLogging,
                    "Administrative action '{$action}' MUST have audit logging implemented"
                );
            }
        }
    }

    /**
     * Invariant: Audit log entries MUST contain actor identity and timestamp
     */
    public function testAuditLogContainsRequiredFields(): void
    {
        $content = file_get_contents($this->adminFile);
        
        // Verify no audit logging exists (current vulnerable state) or proper fields exist
        $hasActorTracking = preg_match('/\$_SESSION\[.*user|actor|admin/i', $content);
        $hasTimestamp = preg_match('/date|time|now/i', $content);
        
        // If any admin action exists without both actor and timestamp, security boundary fails
        $this->assertTrue(
            $hasActorTracking && $hasTimestamp,
            'Audit logging MUST capture actor identity and timestamp for accountability'
        );
    }
}
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->
