### PR TITLE
Improve mobile placeholder contrast

### DIFF
--- a/apps/mobile/src/app/ballot/[key]/index.tsx
+++ b/apps/mobile/src/app/ballot/[key]/index.tsx
@@ -6,6 +6,7 @@ import { CandidateRanking } from '@/components/candidate-ranking';
 import { ElectionResults } from '@/components/election-results';
 import { GroupQuestions } from '@/components/group-questions';
 import { VoteSubmission } from '@/components/vote-submission';
+import { PLACEHOLDER_TEXT_COLOR } from '@/theme/colors';
 import type { GroupAnswers } from '@/features/group-answers';
 import { createRanking } from '@/features/ranking';
 import { useLocalSearchParams } from 'expo-router';
@@ -153,6 +154,7 @@ export default function BallotScreen() {
                   maxLength={100}
                   onChangeText={setVoterName}
                   placeholder="Your name"
+                  placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
                   style={styles.nameInput}
                   textContentType="name"
                   value={voterName}

--- a/apps/mobile/src/app/create.tsx
+++ b/apps/mobile/src/app/create.tsx
@@ -22,6 +22,7 @@ import { TermsAcceptance } from '@/components/terms-acceptance';
 import { getApiBaseUrl } from '@/config/api';
 import { TERMS_OF_SERVICE_URL } from '@/config/service-links';
 import { validateGuestBallot, type GuestBallotFieldErrors } from '@/features/guest-ballot';
+import { PLACEHOLDER_TEXT_COLOR } from '@/theme/colors';
 import { saveBallotManagementToken } from '@/utils/ballot-management-token-store';
 import { loadInstallationId } from '@/utils/installation-id';
 
@@ -241,6 +242,7 @@ export default function CreateBallotScreen() {
               maxLength={64}
               onChangeText={setName}
               placeholder="For example: Team lunch"
+              placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
               returnKeyType="next"
               style={[styles.input, fieldErrors.name && styles.inputError]}
               value={name}
@@ -269,6 +271,7 @@ export default function CreateBallotScreen() {
                   maxLength={256}
                   onChangeText={(value) => updateCandidate(index, value)}
                   placeholder="Candidate name"
+                  placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
                   returnKeyType="next"
                   style={[styles.input, fieldErrors.candidateNames[index] && styles.inputError]}
                   value={candidate}

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
+import { PLACEHOLDER_TEXT_COLOR } from '@/theme/colors';
 import { normalizeShortcode } from '@/utils/shortcode';
 
 export default function HomeScreen() {
@@ -56,6 +57,7 @@ export default function HomeScreen() {
             onChangeText={setShortcode}
             onSubmitEditing={openBallot}
             placeholder="For example: pizza"
+            placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
             returnKeyType="go"
             style={styles.input}
             value={shortcode}

--- a/apps/mobile/src/components/group-questions.tsx
+++ b/apps/mobile/src/components/group-questions.tsx
@@ -1,5 +1,6 @@
 import type { GroupField } from '@/api/legacy-api';
 import type { GroupAnswers, GroupAnswerValue } from '@/features/group-answers';
+import { PLACEHOLDER_TEXT_COLOR } from '@/theme/colors';
 import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 
 type GroupQuestionsProps = {
@@ -58,6 +59,7 @@ export function GroupQuestions({ answers, disabled = false, fields, onChange }: 
                 maxLength={1000}
                 onChangeText={(value) => updateAnswer(field.id, value)}
                 placeholder="Enter your answer"
+                placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
                 style={styles.textInput}
                 value={typeof answer === 'string' ? answer : ''}
               />

--- a/apps/mobile/src/components/vote-submission.tsx
+++ b/apps/mobile/src/components/vote-submission.tsx
@@ -9,6 +9,7 @@ import {
   normalizeVoterCode,
   type PendingVoteRequest,
 } from '@/features/vote-submission';
+import { PLACEHOLDER_TEXT_COLOR } from '@/theme/colors';
 import { loadInstallationId } from '@/utils/installation-id';
 import {
   groupAnswersAreValid,
@@ -144,6 +145,7 @@ export function VoteSubmission({
             maxLength={6}
             onChangeText={(value) => setVoterCode(value.replace(/\s/g, ''))}
             placeholder="Six-character code"
+            placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
             style={styles.codeInput}
             textContentType="oneTimeCode"
             value={voterCode}

--- a/apps/mobile/src/theme/colors.test.ts
+++ b/apps/mobile/src/theme/colors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { PLACEHOLDER_TEXT_COLOR } from './colors';
+
+function relativeLuminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/.{2}/g)!
+    .map((channel) => Number.parseInt(channel, 16) / 255)
+    .map((channel) =>
+      channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('mobile colors', () => {
+  it('keeps placeholder text readable on white input backgrounds', () => {
+    expect(contrastRatio(PLACEHOLDER_TEXT_COLOR, '#ffffff')).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/apps/mobile/src/theme/colors.ts
+++ b/apps/mobile/src/theme/colors.ts
@@ -1,0 +1,1 @@
+export const PLACEHOLDER_TEXT_COLOR = '#52697f';


### PR DESCRIPTION
## Summary

- use the existing blue-gray theme color for placeholder text across every mobile text input
- provide consistent hint contrast on the ballot lookup, ballot creation, voter name, grouping-question, and voter-code fields
- add a regression test requiring WCAG AA contrast against the inputs’ white background

The selected `#52697f` color has a 5.70:1 contrast ratio against white.

## Verification

- `cd apps/mobile && npm test` (24 files, 76 tests)
- `cd apps/mobile && npm run typecheck`
- `cd apps/mobile && npm run lint` (passes with one unrelated pre-existing warning)
- `cd apps/mobile && npm run validate:release`
- `npm test` (193 Vitest tests, 234 PHPUnit tests)
- `npm run build`
- visually verified in the iPhone 17 Pro / iOS 26.5 simulator

## Scope

The separately discovered Borda/STV result-mode discrepancy is intentionally not changed in this PR.