### PR TITLE
Support native Borda results

### DIFF
--- a/apps/mobile/src/api/v2-api.test.ts
+++ b/apps/mobile/src/api/v2-api.test.ts
@@ -223,7 +223,13 @@ describe('V2ApiClient.submitVote', () => {
 describe('V2ApiClient.getResults', () => {
   it('loads typed anonymous election data', async () => {
     const payload = {
-      ballot: { key: 'pizza night', name: 'Pizza', positions: 1, tieBreak: 'weighted' },
+      ballot: {
+        key: 'pizza night',
+        name: 'Pizza',
+        positions: 1,
+        resultMethod: 'borda',
+        tieBreak: 'weighted',
+      },
       candidates: [{ id: 3, name: 'Mushroom' }],
       votes: [[3]],
     };
@@ -234,9 +240,27 @@ describe('V2ApiClient.getResults', () => {
 
     await expect(client.getResults(' pizza night ')).resolves.toEqual(payload);
     expect(fetchImpl).toHaveBeenCalledOnce();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const calledUrl = (fetchImpl.mock.calls as any)[0][0] as string;
     expect(calledUrl).toMatch(/^https:\/\/example\.test\/api\/v2\/results\.php\?key=pizza%20night&_=\d+$/);
+  });
+
+  it('rejects results without a recognized calculation method', async () => {
+    const client = new V2ApiClient({
+      baseUrl: 'https://example.test/api',
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              ballot: { key: 'old', name: 'Old response', positions: 1, tieBreak: 'weighted' },
+              candidates: [{ id: 1, name: 'A' }],
+              votes: [[1]],
+            },
+            error: null,
+          }),
+        ),
+    });
+
+    await expect(client.getResults('old')).rejects.toMatchObject({ code: 'malformed_response' });
   });
 
   it('preserves the unreleased-results state', async () => {

--- a/apps/mobile/src/api/v2-api.ts
+++ b/apps/mobile/src/api/v2-api.ts
@@ -37,6 +37,7 @@ export type ElectionResults = {
     key: string;
     name: string;
     positions: number;
+    resultMethod: 'rcv' | 'borda';
     tieBreak: 'weighted' | 'random';
   };
   candidates: { id: number; name: string }[];
@@ -283,6 +284,7 @@ function isElectionResults(value: unknown): value is ElectionResults {
     typeof ballot.key === 'string' &&
     typeof ballot.name === 'string' &&
     typeof ballot.positions === 'number' &&
+    (ballot.resultMethod === 'rcv' || ballot.resultMethod === 'borda') &&
     (ballot.tieBreak === 'weighted' || ballot.tieBreak === 'random') &&
     value.candidates.every(
       (candidate) => isRecord(candidate) && typeof candidate.id === 'number' && typeof candidate.name === 'string',

--- a/apps/mobile/src/components/election-results.test.tsx
+++ b/apps/mobile/src/components/election-results.test.tsx
@@ -1,8 +1,8 @@
-import { calculateElection } from '@rankedchoices/rcv-core';
+import { calculateBorda, calculateElection } from '@rankedchoices/rcv-core';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { ElectionResultsView } from './election-results';
+import { BordaResultsView, calculateLocalResult, ElectionResultsView } from './election-results';
 
 describe('ElectionResultsView', () => {
   it('renders winners and every local tally round', () => {
@@ -21,5 +21,70 @@ describe('ElectionResultsView', () => {
     expect(html).toContain('Round 1');
     expect(html).toContain(result.winners[0].name);
     expect(html).toContain('Eliminated');
+  });
+});
+
+describe('BordaResultsView', () => {
+  it('renders native Borda winners, scoring guidance, and point totals without RCV rounds', () => {
+    const result = calculateBorda({
+      candidates: [
+        { id: 1, name: 'Pepperoni' },
+        { id: 2, name: 'Supreme' },
+        { id: 3, name: 'Sausage' },
+      ],
+      ballots: [[1, 2, 3], [1, 3, 2], [2, 3, 1]],
+      seats: 2,
+    });
+    const html = renderToStaticMarkup(<BordaResultsView result={result} voteCount={3} />);
+
+    expect(html).toContain('using Borda count');
+    expect(html).toContain('How Borda count works');
+    expect(html).toContain('Point totals');
+    expect(html).toContain('Pepperoni');
+    expect(html).toContain('4 pts');
+    expect(html).not.toContain('Round 1');
+  });
+
+  it('selects Borda calculation when the server marks the ballot as Borda', () => {
+    const local = calculateLocalResult({
+      ballot: {
+        key: 'pizza',
+        name: 'Pizza Contest',
+        positions: 2,
+        resultMethod: 'borda',
+        tieBreak: 'weighted',
+      },
+      candidates: [
+        { id: 1, name: 'Pepperoni' },
+        { id: 2, name: 'Supreme' },
+        { id: 3, name: 'Sausage' },
+      ],
+      votes: [[1, 2, 3], [2, 1, 3]],
+    });
+
+    expect(local.resultMethod).toBe('borda');
+    expect(local.result).toHaveProperty('tally');
+    expect(local.result).not.toHaveProperty('rounds');
+  });
+
+  it('preserves round-based calculation for RCV ballots', () => {
+    const local = calculateLocalResult({
+      ballot: {
+        key: 'ordinary',
+        name: 'Ordinary ballot',
+        positions: 1,
+        resultMethod: 'rcv',
+        tieBreak: 'weighted',
+      },
+      candidates: [
+        { id: 1, name: 'A' },
+        { id: 2, name: 'B' },
+      ],
+      votes: [[1, 2], [1, 2], [2, 1]],
+    });
+
+    expect(local.resultMethod).toBe('rcv');
+    expect(local.result).toHaveProperty('rounds');
+    expect(local.result).not.toHaveProperty('tally');
   });
 });

--- a/apps/mobile/src/components/election-results.tsx
+++ b/apps/mobile/src/components/election-results.tsx
@@ -1,13 +1,41 @@
 import { createV2ApiClient } from '@/api/client';
-import { V2ApiError } from '@/api/v2-api';
-import { calculateElection, type ElectionResult } from '@rankedchoices/rcv-core';
+import { V2ApiError, type ElectionResults as ElectionResultsData } from '@/api/v2-api';
+import {
+  calculateBorda,
+  calculateElection,
+  type BordaResult,
+  type ElectionResult,
+} from '@rankedchoices/rcv-core';
 import { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 type ResultState =
   | { status: 'loading' }
-  | { status: 'loaded'; result: ElectionResult; voteCount: number }
+  | ({ status: 'loaded'; voteCount: number } & LocalResult)
   | { status: 'error'; error: V2ApiError };
+
+type LocalResult =
+  | { resultMethod: 'rcv'; result: ElectionResult }
+  | { resultMethod: 'borda'; result: BordaResult };
+
+export function calculateLocalResult(data: ElectionResultsData): LocalResult {
+  const sharedInput = {
+    candidates: data.candidates,
+    ballots: data.votes,
+    seats: data.ballot.positions,
+  };
+  if (data.ballot.resultMethod === 'borda') {
+    return { resultMethod: 'borda', result: calculateBorda(sharedInput) };
+  }
+  return {
+    resultMethod: 'rcv',
+    result: calculateElection({
+      ...sharedInput,
+      tieBreak: data.ballot.tieBreak,
+      ballotKey: data.ballot.key,
+    }),
+  };
+}
 
 export function ElectionResults({ ballotKey }: { ballotKey: string }) {
   const client = useMemo(() => createV2ApiClient(), []);
@@ -21,13 +49,7 @@ export function ElectionResults({ ballotKey }: { ballotKey: string }) {
         setState({
           status: 'loaded',
           voteCount: data.votes.length,
-          result: calculateElection({
-            candidates: data.candidates,
-            ballots: data.votes,
-            seats: data.ballot.positions,
-            tieBreak: data.ballot.tieBreak,
-            ballotKey: data.ballot.key,
-          }),
+          ...calculateLocalResult(data),
         });
       },
       (error: unknown) => {
@@ -79,7 +101,11 @@ export function ElectionResults({ ballotKey }: { ballotKey: string }) {
     );
   }
 
-  return <ElectionResultsView result={state.result} voteCount={state.voteCount} />;
+  return state.resultMethod === 'borda' ? (
+    <BordaResultsView result={state.result} voteCount={state.voteCount} />
+  ) : (
+    <ElectionResultsView result={state.result} voteCount={state.voteCount} />
+  );
 }
 
 export function ElectionResultsView({
@@ -126,6 +152,58 @@ export function ElectionResultsView({
   );
 }
 
+export function BordaResultsView({
+  result,
+  voteCount,
+}: {
+  result: BordaResult;
+  voteCount: number;
+}) {
+  const firstPlacePoints = Math.max(0, result.cap - 1);
+  return (
+    <View accessibilityLabel="Local Borda results" style={styles.results}>
+      <Text style={styles.sectionTitle}>Current results</Text>
+      <Text style={styles.summary}>
+        Calculated on this device from {voteCount} {voteCount === 1 ? 'vote' : 'votes'} using
+        Borda count.
+      </Text>
+
+      <View style={styles.winnerCard}>
+        <Text style={styles.winnerLabel}>{result.winners.length === 1 ? 'Winner' : 'Winners'}</Text>
+        <Text style={styles.winnerNames}>
+          {result.winners.length > 0
+            ? result.winners.map((candidate) => candidate.name).join(', ')
+            : 'No winner yet'}
+        </Text>
+      </View>
+
+      <View style={styles.methodCard}>
+        <Text style={styles.cardTitle}>How Borda count works</Text>
+        <Text style={styles.methodText}>
+          A first-place ranking earns {firstPlacePoints} {firstPlacePoints === 1 ? 'point' : 'points'},
+          with one fewer point for each lower rank. Unranked choices and ranks after {result.cap} earn
+          0 points.
+        </Text>
+      </View>
+
+      <View style={styles.roundCard}>
+        <Text style={styles.roundTitle}>Point totals</Text>
+        {result.tally.map((candidate) => (
+          <View key={candidate.id} style={styles.tallyRow}>
+            <Text style={styles.tallyName}>{candidate.name}</Text>
+            <Text style={styles.tallyVotes}>
+              {candidate.points} {candidate.points === 1 ? 'pt' : 'pts'}
+            </Text>
+          </View>
+        ))}
+        {result.tieBreakApplied ? (
+          <Text style={styles.outcomeText}>The final seat tie was broken by first-place rankings.</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
 function candidateName(result: ElectionResult, id: number): string {
   return result.candidates.find((candidate) => candidate.id === id)?.name ?? `Choice ${id}`;
 }
@@ -145,6 +223,9 @@ const styles = StyleSheet.create({
   winnerNames: { color: '#125435', fontSize: 21, fontWeight: '800', marginTop: 4 },
   roundCard: { backgroundColor: '#ffffff', borderRadius: 14, marginTop: 12, padding: 16 },
   roundTitle: { color: '#12355b', fontSize: 18, fontWeight: '800', marginBottom: 8 },
+  methodCard: { backgroundColor: '#eef3f7', borderRadius: 14, marginTop: 12, padding: 16 },
+  cardTitle: { color: '#12355b', fontSize: 16, fontWeight: '800' },
+  methodText: { color: '#344a5f', fontSize: 14, lineHeight: 20, marginTop: 6 },
   tallyRow: { flexDirection: 'row', gap: 12, justifyContent: 'space-between', paddingVertical: 4 },
   tallyName: { color: '#344a5f', flex: 1, fontSize: 14 },
   tallyVotes: { color: '#1f3143', fontSize: 14, fontWeight: '700' },

--- a/apps/mobile/src/features/rcv-core.test.ts
+++ b/apps/mobile/src/features/rcv-core.test.ts
@@ -1,4 +1,4 @@
-import { calculateElection } from '@rankedchoices/rcv-core';
+import { calculateBorda, calculateElection } from '@rankedchoices/rcv-core';
 import { describe, expect, it } from 'vitest';
 
 const candidates = ['A', 'B', 'C', 'D'].map((name, index) => ({ id: index + 1, name }));
@@ -79,5 +79,73 @@ describe('calculateElection legacy parity fixtures', () => {
     };
 
     expect(calculateElection(input)).toEqual(calculateElection(input));
+  });
+});
+
+describe('calculateBorda legacy parity fixtures', () => {
+  it('awards descending rank points and elects the configured number of candidates', () => {
+    const result = calculateBorda({
+      candidates,
+      ballots: ballots([
+        ['A', 'B', 'C', 'D'],
+        ['B', 'A', 'C', 'D'],
+        ['C', 'A', 'B', 'D'],
+      ]),
+      seats: 2,
+    });
+
+    expect(result.cap).toBe(4);
+    expect(result.tally.map(({ name, points }) => [name, points])).toEqual([
+      ['A', 7],
+      ['B', 6],
+      ['C', 5],
+      ['D', 0],
+    ]);
+    expect(result.winners.map((candidate) => candidate.name)).toEqual(['A', 'B']);
+  });
+
+  it('uses first-place votes only to resolve a tie spanning the seat boundary', () => {
+    const result = calculateBorda({
+      candidates: candidates.slice(0, 3),
+      ballots: ballots([
+        ['A', 'B'],
+        ['A', 'B'],
+        ['C', 'B'],
+        ['C', 'B'],
+      ]),
+      seats: 2,
+    });
+
+    expect(result.tally.map(({ name, points, firstPlaceVotes }) => [name, points, firstPlaceVotes])).toEqual([
+      ['A', 4, 2],
+      ['C', 4, 2],
+      ['B', 4, 0],
+    ]);
+    expect(result.winners.map((candidate) => candidate.name)).toEqual(['A', 'C']);
+    expect(result.tieBreakApplied).toBe(true);
+  });
+
+  it('gives no points to unranked choices and reports average rank', () => {
+    const result = calculateBorda({
+      candidates: candidates.slice(0, 3),
+      ballots: ballots([
+        ['A', 'B'],
+        ['B', 'A'],
+        ['A'],
+      ]),
+    });
+
+    expect(result.tally.find((candidate) => candidate.name === 'A')).toMatchObject({
+      points: 5,
+      firstPlaceVotes: 2,
+      rankCounts: { 1: 2, 2: 1 },
+      averageRank: 1.3,
+    });
+    expect(result.tally.find((candidate) => candidate.name === 'C')).toMatchObject({
+      points: 0,
+      firstPlaceVotes: 0,
+      rankCounts: {},
+      averageRank: null,
+    });
   });
 });

--- a/docs/expo-migration-rfc.md
+++ b/docs/expo-migration-rfc.md
@@ -400,7 +400,8 @@ unchanged.
   reset controls; gestures are an enhancement, not the only control.
 - Submit votes online with clear loading, retry, duplicate, secure-code, and
   cutoff states.
-- Extract `rcv-core` and render local round results.
+- Extract `rcv-core` and render local RCV round results or Borda point totals,
+  according to an explicit result method supplied by the server.
 - Support the canonical `/ballot/[key]` route and test incoming links in a
   development build.
 - Cover the flow with API contract tests and one device-level E2E scenario.
@@ -448,6 +449,13 @@ passes it to the native system share sheet. The URL is included in both the
 cross-platform message and the iOS URL field so shared links are canonical on
 both platforms.
 
+TestFlight review exposed a result-method gap: the legacy `pizza` ballot uses
+Borda count, while the initial v2 results contract omitted that setting and the
+native client therefore calculated RCV rounds. The v2 contract now normalizes
+the legacy flag as `resultMethod: "rcv" | "borda"`; `rcv-core` implements the
+website's existing Borda scoring and seat-boundary first-place tie break, and
+the native view renders winners plus point totals without RCV rounds.
+
 ### Phase 3 — authentication and management
 
 - Implement server-side password hashing, migrate legacy hashes on successful
@@ -465,7 +473,8 @@ logged-in user can safely manage only their own ballots.
 
 - RCVis display/synchronization.
 - Full grouping management and exports.
-- Borda views, custom entries, delayed results, and administrative tools.
+- Detailed Borda breakdowns, custom entries, delayed results, and
+  administrative tools.
 - Revisit initially web-only owner workflows only where native demand warrants
   them; permanently web-only features remain on RankedChoices.com.
 - Run the Expo-web proof and decide whether, when, and how to replace AngularJS.
@@ -550,9 +559,10 @@ results path has now passed on both Android and an iOS simulator against the
 real local PHP/MySQL backend. Xcode MCP also completed a clean native iOS build.
 
 Production distribution follows `docs/mobile-release-checklist.md`. David
-Moritz has confirmed that he will own and control both store listings. The
-Apple account type, team access, Expo ownership, and signing workflow still
-must be confirmed before registering or uploading the production identifiers.
+Moritz has confirmed that he will own and control both store listings. He has
+uploaded an iOS build to TestFlight, and Elisabeth has accepted App Store
+Connect team access and installed the app from TestFlight. Durable Expo
+ownership and the Google Play signing workflow still require confirmation.
 The app-side production/staging link declarations and
 non-deployable association templates may be reviewed in advance, but the
 server files require the final Apple Team ID and Google Play app-signing

--- a/docs/mobile-release-checklist.md
+++ b/docs/mobile-release-checklist.md
@@ -30,6 +30,9 @@ only under store-specific eligibility rules and should not be the launch plan.
   the management-token table, unique digest index, and ballot lookup index.
 - [ ] Deploy the v2 ballot, vote, and results endpoints plus their guarded
   legacy dependencies.
+- [ ] Deploy the additive results `resultMethod` contract before uploading a
+  mobile build that requires it; verify ordinary ballots return `rcv` and a
+  maintainer-approved Borda ballot returns `borda`.
 - [ ] Verify GET requests receive the documented method/error envelope and run
   a disposable production smoke ballot approved by the maintainer. Remove all
   smoke data after verification.
@@ -130,6 +133,8 @@ never place voter codes or management credentials in a report.
 - [ ] iOS simulator and at least one physical iPhone cover lookup, guest
   creation, SecureStore recovery messaging, voting, results, sharing, cold
   launch links, network failure/retry, larger text, and VoiceOver basics.
+- [ ] Compare one released Borda ballot's native winners and point totals with
+  the website, and confirm the native view does not show RCV rounds.
 - [ ] Test current and oldest supported OS versions where practical.
 
 Safety check: use disposable records and record the shortcode or database ID

--- a/packages/rcv-core/README.md
+++ b/packages/rcv-core/README.md
@@ -1,6 +1,6 @@
 # `@rankedchoices/rcv-core`
 
-Pure TypeScript ranked-choice election calculation shared by native clients. The package has no
+Pure TypeScript ranked-choice and Borda election calculation shared by native clients. The package has no
 AngularJS, DOM, network, or storage dependencies. It intentionally preserves the legacy
-RankedChoices quota, surplus-transfer, and deterministic tie-break behavior so parity fixtures can
+RankedChoices quota, surplus-transfer, Borda scoring, and tie-break behavior so parity fixtures can
 be run while the clients migrate.

--- a/packages/rcv-core/src/index.ts
+++ b/packages/rcv-core/src/index.ts
@@ -34,9 +34,102 @@ export type ElectionResult = {
   seats: number;
 };
 
+export type BordaInput = {
+  candidates: readonly RcvCandidate[];
+  ballots: readonly (readonly CandidateId[])[];
+  seats?: number;
+};
+
+export type BordaTally = RcvCandidate & {
+  points: number;
+  firstPlaceVotes: number;
+  percent: number;
+  rankCounts: Record<number, number>;
+  averageRank: number | null;
+};
+
+export type BordaResult = {
+  candidates: RcvCandidate[];
+  winners: RcvCandidate[];
+  tally: BordaTally[];
+  seats: number;
+  cap: number;
+  tieBreakApplied: boolean;
+};
+
 function round(value: number, precision: number): number {
   const factor = 10 ** precision;
   return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function calculateBorda(input: BordaInput): BordaResult {
+  const candidates = input.candidates.filter(
+    (candidate, index, all) => all.findIndex((item) => item.id === candidate.id) === index,
+  );
+  if (candidates.length === 0) {
+    return { candidates: [], winners: [], tally: [], seats: 0, cap: 0, tieBreakApplied: false };
+  }
+
+  const seats = Math.max(1, Math.min(Math.trunc(input.seats ?? 1), candidates.length));
+  const cap = Math.min(candidates.length, Math.max(seats, 10));
+  const validIds = new Set(candidates.map((candidate) => candidate.id));
+  const ballots = input.ballots.map((ballot) =>
+    ballot.filter(
+      (id, index, ranking) => validIds.has(id) && ranking.indexOf(id) === index,
+    ),
+  );
+  const maxPoints = ballots.length * Math.max(0, cap - 1);
+
+  const tally = candidates.map<BordaTally>((candidate) => {
+    let points = 0;
+    let firstPlaceVotes = 0;
+    let rankSum = 0;
+    let totalRanked = 0;
+    const rankCounts: Record<number, number> = {};
+
+    ballots.forEach((ballot) => {
+      const rank = ballot.indexOf(candidate.id);
+      if (rank < 0) return;
+      points += Math.max(0, cap - 1 - rank);
+      firstPlaceVotes += rank === 0 ? 1 : 0;
+      rankCounts[rank + 1] = (rankCounts[rank + 1] ?? 0) + 1;
+      rankSum += rank + 1;
+      totalRanked += 1;
+    });
+
+    return {
+      ...candidate,
+      points,
+      firstPlaceVotes,
+      percent: maxPoints > 0 ? round((points / maxPoints) * 100, 1) : 0,
+      rankCounts,
+      averageRank: totalRanked > 0 ? round(rankSum / totalRanked, 1) : null,
+    };
+  });
+
+  tally.sort((left, right) => right.points - left.points);
+
+  let tieBreakApplied = false;
+  if (tally.length > seats && tally[seats - 1].points === tally[seats].points) {
+    const tiedPoints = tally[seats - 1].points;
+    let tieStart = seats - 1;
+    while (tieStart > 0 && tally[tieStart - 1].points === tiedPoints) tieStart -= 1;
+    let tieEnd = seats;
+    while (tieEnd < tally.length - 1 && tally[tieEnd + 1].points === tiedPoints) tieEnd += 1;
+    const tied = tally.splice(tieStart, tieEnd - tieStart + 1);
+    tied.sort((left, right) => right.firstPlaceVotes - left.firstPlaceVotes);
+    tally.splice(tieStart, 0, ...tied);
+    tieBreakApplied = tally[seats - 1].firstPlaceVotes > tally[seats].firstPlaceVotes;
+  }
+
+  return {
+    candidates,
+    winners: tally.slice(0, seats).map(({ id, name }) => ({ id, name })),
+    tally,
+    seats,
+    cap,
+    tieBreakApplied,
+  };
 }
 
 function deterministicScore(ballotKey: string, candidateId: CandidateId, roundNumber: number) {

--- a/src/api/v2/README.md
+++ b/src/api/v2/README.md
@@ -89,6 +89,8 @@ the anonymous client.
 
 ## `GET /api/v2/results.php?key=ballot-shortcode`
 
-Returns the ballot's candidate IDs and anonymous ranked votes for local RCV
-calculation. The endpoint enforces `resultsRelease` before returning any vote
-data and responds with `results_not_released` while results are private.
+Returns the ballot's candidate IDs, anonymous ranked votes, and normalized
+`resultMethod` (`rcv` or `borda`) for local calculation. The endpoint enforces
+`resultsRelease` before returning any vote data and responds with
+`results_not_released` while results are private. Deploy this additive server
+contract before releasing a mobile client that requires `resultMethod`.

--- a/src/api/v2/results.php
+++ b/src/api/v2/results.php
@@ -27,7 +27,7 @@ if ($key === '') {
 }
 
 $ballotStatement = $dbh->prepare(
-    'SELECT id, name, positions, tieBreak, resultsRelease FROM ballots WHERE `key` = :key LIMIT 1'
+    'SELECT id, name, positions, tieBreak, resultsRelease, bordaActive FROM ballots WHERE `key` = :key LIMIT 1'
 );
 $ballotStatement->bindValue(':key', $key, PDO::PARAM_STR);
 $ballotStatement->execute();
@@ -75,6 +75,7 @@ resultsRespond(200, [
         'name' => (string) $ballot['name'],
         'positions' => (int) $ballot['positions'],
         'tieBreak' => $ballot['tieBreak'] === 'random' ? 'random' : 'weighted',
+        'resultMethod' => (int) $ballot['bordaActive'] === 1 ? 'borda' : 'rcv',
     ],
     'candidates' => $entries,
     'votes' => $votes,

--- a/test/borda.test.js
+++ b/test/borda.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { computeBorda } from '@src/js/utils/borda.js';
+import { calculateBorda } from '../packages/rcv-core/src/index.ts';
 
 function makeEntryMap(names) {
   var map = {};
@@ -7,6 +8,12 @@ function makeEntryMap(names) {
     map[i + 1] = { name: name, image: '', color: '', hyperlink: '' };
   });
   return map;
+}
+
+function makeCandidates(names) {
+  return names.map(function (name, index) {
+    return { id: index + 1, name: name };
+  });
 }
 
 describe('computeBorda', () => {
@@ -340,5 +347,43 @@ describe('computeBorda', () => {
 
     expect(result.tally[0].image).toBe('alice.png');
     expect(result.tally[0].color).toBe('ff0000');
+  });
+});
+
+describe('native Borda parity', () => {
+  it('matches the website scoring and seat-boundary tie break', () => {
+    var names = ['Alice', 'Bob', 'Carol'];
+    var ids = [1, 2, 3];
+    var votes = [
+      [1, 2],
+      [1, 2],
+      [3, 2],
+      [3, 2]
+    ];
+    var web = computeBorda(votes, ids, makeEntryMap(names), 2);
+    var native = calculateBorda({ candidates: makeCandidates(names), ballots: votes, seats: 2 });
+
+    expect(native.cap).toBe(web.cap);
+    expect(native.tieBreakApplied).toBe(web.tieBreakApplied);
+    expect(native.winners[0].name).toBe(web.winner.name);
+    expect(native.tally.map(function (candidate) {
+      return {
+        name: candidate.name,
+        points: candidate.points,
+        firstPlaceVotes: candidate.firstPlaceVotes,
+        percent: candidate.percent,
+        rankCounts: candidate.rankCounts,
+        avgRank: candidate.averageRank
+      };
+    })).toEqual(web.tally.map(function (candidate) {
+      return {
+        name: candidate.name,
+        points: candidate.points,
+        firstPlaceVotes: candidate.firstPlaceVotes,
+        percent: candidate.percent,
+        rankCounts: candidate.rankCounts,
+        avgRank: candidate.avgRank
+      };
+    }));
   });
 });

--- a/test/contract/README.md
+++ b/test/contract/README.md
@@ -34,6 +34,7 @@ The suite currently verifies a small but high-signal flow:
 - `get-candidates.php` success and missing-key plain-text error
 - `vote.php` success and validation error envelope
 - `get-votes.php` success after casting a real vote
+- `v2/results.php` normalized RCV/Borda result methods
 
 Each test run creates a unique ballot through the public API and then attempts
 to delete its votes and ballot during cleanup.

--- a/test/contract/live-php-api.test.js
+++ b/test/contract/live-php-api.test.js
@@ -39,7 +39,13 @@ async function requestApi(method, endpoint, { query, body } = {}) {
   };
 }
 
-async function createBallot({ isSecure = false, codeCount = 0, allowGrouping = false } = {}) {
+async function createBallot({
+  isSecure = false,
+  codeCount = 0,
+  allowGrouping = false,
+  bordaActive = false,
+  resultsReleased = false
+} = {}) {
   const uniqueId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const key = `contract-${uniqueId}`;
   const createdBy = `contract-test-${uniqueId}`;
@@ -52,7 +58,7 @@ async function createBallot({ isSecure = false, codeCount = 0, allowGrouping = f
       positions: '1',
       createdBy,
       sqlVoteCutoff: '2099-12-31 23:59:59',
-      sqlResultsRelease: '2099-12-31 23:59:59',
+      sqlResultsRelease: resultsReleased ? '2000-01-01 00:00:00' : '2099-12-31 23:59:59',
       isSecure,
       codeCount,
       allowGrouping
@@ -75,6 +81,21 @@ async function createBallot({ isSecure = false, codeCount = 0, allowGrouping = f
   });
 
   expect(addEntries.text).toBe('Success');
+
+  if (bordaActive) {
+    const updated = await requestApi('POST', 'update-ballot.php', {
+      body: {
+        id: ballotId,
+        key,
+        name: ballotName,
+        positions: '1',
+        createdBy,
+        sqlResultsRelease: '2000-01-01 00:00:00',
+        bordaActive: 1
+      }
+    });
+    expect(updated.json).toEqual({ data: { success: true } });
+  }
 
   return {
     ballotId,
@@ -123,6 +144,27 @@ afterEach(async () => {
 });
 
 describe('live PHP API contracts', () => {
+  it('returns normalized RCV and Borda result methods', async () => {
+    const rcvBallot = await createBallot({ resultsReleased: true });
+    const bordaBallot = await createBallot({ bordaActive: true, resultsReleased: true });
+
+    const rcvResults = await requestApi('GET', 'v2/results.php', {
+      query: { key: rcvBallot.key }
+    });
+    const bordaResults = await requestApi('GET', 'v2/results.php', {
+      query: { key: bordaBallot.key }
+    });
+
+    expect(rcvResults).toMatchObject({
+      status: 200,
+      json: { data: { ballot: { resultMethod: 'rcv' } }, error: null }
+    });
+    expect(bordaResults).toMatchObject({
+      status: 200,
+      json: { data: { ballot: { resultMethod: 'borda' } }, error: null }
+    });
+  });
+
   it('records and safely replays an idempotent v2 anonymous vote', async () => {
     const ballot = await createBallot();
     const candidates = await requestApi('GET', 'get-candidates.php', {

--- a/test/php/V2ResultsTest.php
+++ b/test/php/V2ResultsTest.php
@@ -22,9 +22,27 @@ class V2ResultsTest extends ApiTestCase
         $this->assertNull($result['body']['error']);
         $this->assertSame('Favorite fruit', $result['body']['data']['ballot']['name']);
         $this->assertSame(2, $result['body']['data']['ballot']['positions']);
+        $this->assertSame('rcv', $result['body']['data']['ballot']['resultMethod']);
         $this->assertSame('weighted', $result['body']['data']['ballot']['tieBreak']);
         $this->assertSame($entryIds, array_column($result['body']['data']['candidates'], 'id'));
         $this->assertSame([array_reverse($entryIds)], $result['body']['data']['votes']);
+    }
+
+    public function testReturnsNormalizedBordaResultMethod(): void
+    {
+        $key = 'borda-results-' . uniqid();
+        $ballotId = $this->seedBallot([
+            'key' => $key,
+            'bordaActive' => 1,
+            'resultsRelease' => '2000-01-01 00:00:00',
+        ]);
+        $entryIds = $this->seedEntries($ballotId, ['Apple', 'Pear']);
+        $this->seedVote($ballotId, '["Apple","Pear"]', implode(',', $entryIds));
+
+        $result = $this->callApi('v2/results.php', [], ['key' => $key]);
+
+        $this->assertNull($result['body']['error']);
+        $this->assertSame('borda', $result['body']['data']['ballot']['resultMethod']);
     }
 
     public function testDoesNotExposeUnreleasedResults(): void


### PR DESCRIPTION
## Summary

- expose the legacy Borda setting as a normalized `resultMethod: "rcv" | "borda"` in the v2 results contract
- add a framework-neutral TypeScript Borda calculator with website-parity scoring and seat-boundary tie breaking
- select the correct native result calculation and render Borda winners, scoring guidance, and point totals without RCV rounds
- update the migration RFC, API documentation, and release checklist with the server-first rollout requirement

## Safe rollout

Deploy the additive `src/api/v2/results.php` change before releasing the dependent mobile build. Existing installed clients ignore the added response field; the new client deliberately rejects responses without a recognized result method instead of silently calculating the wrong election mode.

## Verification

- `npm test` (194 Vitest tests; 235 PHPUnit tests / 598 assertions)
- direct native-vs-website Borda parity fixture
- `cd apps/mobile && npm test` (24 files, 83 tests)
- `cd apps/mobile && npm run typecheck`
- `cd apps/mobile && npm run lint`
- `cd apps/mobile && npm run validate:release`
- `cd apps/mobile && npx expo export --platform web`
- `npm run build`
- isolated live MySQL RCV/Borda result-method contract
- disposable Borda ballot verified in the iPhone 17 Pro / iOS 26.5 simulator, including accessibility output; test data removed afterward

## PR relationship

This work was developed directly on top of #95 as requested. PR #95 merged while this change was being verified, and GitHub therefore rejected linking the already-merged PR into a new Stacked PRs stack. This successor PR is rebased onto that merge and targets `master`, so its diff contains only the Borda layer.